### PR TITLE
feat: add ChartPublic model

### DIFF
--- a/models/ChartPublic.js
+++ b/models/ChartPublic.js
@@ -1,0 +1,28 @@
+const SQ = require('sequelize');
+const { db } = require('../index');
+const Chart = require('./Chart');
+
+class ChartPublic extends SQ.Model {}
+
+ChartPublic.init(
+    {
+        id: { type: SQ.STRING(5), primaryKey: true },
+        type: SQ.STRING,
+        title: SQ.STRING,
+        metadata: SQ.JSON,
+        external_data: SQ.STRING(),
+        first_published_at: SQ.DATE(),
+        author_id: SQ.INTEGER(),
+        organization_id: SQ.STRING(128)
+    },
+    {
+        sequelize: db,
+        tableName: 'chart_public',
+        modelName: 'chart_public',
+        createdAt: 'first_published_at'
+    }
+);
+
+ChartPublic.belongsTo(Chart, { foreignKey: 'id' });
+
+module.exports = ChartPublic;

--- a/models/index.js
+++ b/models/index.js
@@ -5,6 +5,7 @@ const models = {};
     'Action',
     'AuthToken',
     'Chart',
+    'ChartPublic',
     'ChartAccessToken', // deprecated
     'ExportJob',
     'Folder',

--- a/tests/chart/chart-public-1.test.js
+++ b/tests/chart/chart-public-1.test.js
@@ -1,0 +1,21 @@
+const test = require('ava');
+const { close, init } = require('../index');
+
+test.before(async t => {
+    await init();
+    const { ChartPublic } = require('../../models');
+    t.context.publicChart = await ChartPublic.findByPk('aaaaa');
+});
+
+test('public chart exists', async t => {
+    t.is(t.context.publicChart.id, 'aaaaa');
+});
+
+test('associated chart exists', async t => {
+    const chart = await t.context.publicChart.getChart();
+    t.is(t.context.publicChart.id, chart.id);
+    t.is(t.context.publicChart.title, 'Test chart public');
+    t.is(chart.title, 'Test chart');
+});
+
+test.after(t => close);


### PR DESCRIPTION
Add a `ChartPublic` model with relation to `Chart` model.

It seems like the same problem with the metadata type exists here. In the Testing DB the type is `longtext`.
I changed it locally in my DB but don't who can do it for the testing DB.