### PR TITLE
get "merged" theme data and assets

### DIFF
--- a/models/Theme.js
+++ b/models/Theme.js
@@ -63,4 +63,22 @@ Theme.prototype.getMergedData = async function() {
     return merged;
 };
 
+/*
+ * retreive "merged" theme assets, which is the theme assets
+ * with all assets of "extended" themes merged into it.
+ */
+Theme.prototype.getMergedAssets = async function() {
+    let theme = this;
+    const assets = [theme.get('assets')];
+    while (theme.get('extend')) {
+        theme = await Theme.findByPk(theme.get('extend'));
+        if (theme.get('assets')) assets.push(theme.get('assets'));
+    }
+    let merged = {};
+    while (assets.length) {
+        merged = assign(merged, assets.pop());
+    }
+    return merged;
+};
+
 module.exports = Theme;

--- a/models/Theme.js
+++ b/models/Theme.js
@@ -1,5 +1,6 @@
 const SQ = require('sequelize');
 const { db } = require('../index');
+const assign = require('assign-deep');
 
 const Theme = db.define(
     'theme',
@@ -32,5 +33,23 @@ const Theme = db.define(
 );
 
 Theme.belongsTo(Theme, { foreignKey: 'extend' });
+
+/*
+ * retreive "flattened" theme data, which is the theme data
+ * with all data of "extended" themes merged into it.
+ */
+Theme.prototype.getFlatThemeData = async function() {
+    let theme = this;
+    const data = [theme.get('data')];
+    while (theme.get('extend')) {
+        theme = await Theme.findByPk(theme.get('extend'));
+        data.push(theme.get('data'));
+    }
+    let flat = {};
+    while (data.length) {
+        flat = assign(flat, data.pop());
+    }
+    return flat;
+};
 
 module.exports = Theme;

--- a/models/Theme.js
+++ b/models/Theme.js
@@ -76,7 +76,7 @@ Theme.prototype.getMergedAssets = async function() {
     }
     let merged = {};
     while (assets.length) {
-        merged = assign(merged, assets.pop());
+        merged = Object.assign(merged, assets.pop());
     }
     return merged;
 };

--- a/models/Theme.js
+++ b/models/Theme.js
@@ -11,7 +11,18 @@ const Theme = db.define(
 
         title: SQ.STRING(128),
 
-        data: SQ.TEXT,
+        data: {
+            type: SQ.TEXT,
+            allowNull: false,
+            get() {
+                const d = this.getDataValue('data');
+                return JSON.parse(d);
+            },
+            set(data) {
+                this.setDataValue('data', JSON.stringify(data, null, 4));
+            }
+        },
+
         less: SQ.TEXT,
         assets: SQ.TEXT
     },

--- a/models/Theme.js
+++ b/models/Theme.js
@@ -46,21 +46,21 @@ const Theme = db.define(
 Theme.belongsTo(Theme, { foreignKey: 'extend' });
 
 /*
- * retreive "flattened" theme data, which is the theme data
+ * retreive "merged" theme data, which is the theme data
  * with all data of "extended" themes merged into it.
  */
-Theme.prototype.getFlatThemeData = async function() {
+Theme.prototype.getMergedData = async function() {
     let theme = this;
     const data = [theme.get('data')];
     while (theme.get('extend')) {
         theme = await Theme.findByPk(theme.get('extend'));
         data.push(theme.get('data'));
     }
-    let flat = {};
+    let merged = {};
     while (data.length) {
-        flat = assign(flat, data.pop());
+        merged = assign(merged, data.pop());
     }
-    return flat;
+    return merged;
 };
 
 module.exports = Theme;

--- a/models/Theme.js
+++ b/models/Theme.js
@@ -25,7 +25,18 @@ const Theme = db.define(
         },
 
         less: SQ.TEXT,
-        assets: SQ.TEXT
+
+        assets: {
+            type: SQ.TEXT,
+            allowNull: false,
+            get() {
+                const d = this.getDataValue('assets');
+                return JSON.parse(d);
+            },
+            set(assets) {
+                this.setDataValue('assets', JSON.stringify(assets, null, 4));
+            }
+        }
     },
     {
         tableName: 'theme'

--- a/package-lock.json
+++ b/package-lock.json
@@ -812,6 +812,21 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "assign-deep": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/assign-deep/-/assign-deep-1.0.1.tgz",
+      "integrity": "sha512-CSXAX79mibneEYfqLT5FEmkqR5WXF+xDRjgQQuVf6wSCXCYU8/vHttPidNar7wJ5BFmKAo8Wei0rCtzb+M/yeA==",
+      "requires": {
+        "assign-symbols": "^2.0.2"
+      },
+      "dependencies": {
+        "assign-symbols": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-2.0.2.tgz",
+          "integrity": "sha512-9sBQUQZMKFKcO/C3Bo6Rx4CQany0R0UeVcefNGRRdW2vbmaMOhV1sbmlXcQLcD56juLXbSGTBm0GGuvmrAF8pA=="
+        }
+      }
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "url": "git+https://github.com/datawrapper/orm.git"
     },
     "dependencies": {
+        "assign-deep": "^1.0.1",
         "mysql2": "^1.6.4",
         "nanoid": "^2.0.0",
         "sequelize": "6.0.0",

--- a/tests/theme/theme-1.test.js
+++ b/tests/theme/theme-1.test.js
@@ -47,8 +47,11 @@ test('theme.getFlatThemeData', async t => {
     t.is(typeof t.context.getFlatThemeData, 'function', 'theme.getFlatThemeData() is undefined');
     const data = await t.context.getFlatThemeData();
     t.is(typeof data, 'object');
+    // check a property coming from the theme itself
     t.is(data.colors.general.background, '#f9f9f9');
+    // check a property coming from parent theme "datawrapper"
     t.is(data.colors.general.padding, 0);
+    // check a property coming from grand-parents theme "default"
     t.is(data.easing, 'easeInOut');
 });
 

--- a/tests/theme/theme-1.test.js
+++ b/tests/theme/theme-1.test.js
@@ -47,9 +47,9 @@ test('set theme.data', async t => {
     t.is(theme.data.typography.chart.fontSize, 13);
 });
 
-test('theme.getFlatThemeData', async t => {
-    t.is(typeof t.context.getFlatThemeData, 'function', 'theme.getFlatThemeData() is undefined');
-    const data = await t.context.getFlatThemeData();
+test('theme.getMergedData', async t => {
+    t.is(typeof t.context.getMergedData, 'function', 'theme.getMergedData() is undefined');
+    const data = await t.context.getMergedData();
     t.is(typeof data, 'object');
     // check a property coming from the theme itself
     t.is(data.colors.general.background, '#f9f9f9');

--- a/tests/theme/theme-1.test.js
+++ b/tests/theme/theme-1.test.js
@@ -59,4 +59,13 @@ test('theme.getMergedData', async t => {
     t.is(data.easing, 'easeInOut');
 });
 
+test('theme.getMergedAssets', async t => {
+    t.is(typeof t.context.getMergedAssets, 'function', 'theme.getMergedAssets() is undefined');
+    const assets = await t.context.getMergedAssets();
+    t.is(typeof assets, 'object');
+    // check a property coming from the theme itself
+    t.truthy(assets.Roboto);
+    t.truthy(assets.Helvetica);
+});
+
 test.after(t => close);

--- a/tests/theme/theme-1.test.js
+++ b/tests/theme/theme-1.test.js
@@ -1,0 +1,46 @@
+const test = require('ava');
+const { close, init } = require('../index');
+
+/*
+ * user 2 is an editor who has one chart
+ */
+
+test.before(async t => {
+    await init();
+    const { Theme } = require('../../models');
+    t.context = await Theme.findByPk('datawrapper-blog');
+});
+
+test('get theme.data', t => {
+    const data = t.context.data;
+    t.is(typeof data, 'object');
+    t.is(data.colors.general.background, '#f9f9f9');
+});
+
+test('set theme.data', async t => {
+    let theme = t.context;
+    const data = theme.get('data');
+
+    // set fontsize to 15
+    data.typography.chart.fontSize = 15;
+    theme.set('data', data);
+
+    // check if local data is ok
+    t.is(theme.get('data').typography.chart.fontSize, 15);
+
+    // save change to DB
+    await theme.save();
+
+    // check if change has been saved properly
+    await theme.reload();
+    t.is(theme.data.typography.chart.fontSize, 15);
+
+    // reset value to 13
+    data.typography.chart.fontSize = 13;
+    theme.set('data', data);
+    await theme.save();
+    await theme.reload();
+    t.is(theme.data.typography.chart.fontSize, 13);
+});
+
+test.after(t => close);

--- a/tests/theme/theme-1.test.js
+++ b/tests/theme/theme-1.test.js
@@ -43,4 +43,13 @@ test('set theme.data', async t => {
     t.is(theme.data.typography.chart.fontSize, 13);
 });
 
+test('theme.getFlatThemeData', async t => {
+    t.is(typeof t.context.getFlatThemeData, 'function', 'theme.getFlatThemeData() is undefined');
+    const data = await t.context.getFlatThemeData();
+    t.is(typeof data, 'object');
+    t.is(data.colors.general.background, '#f9f9f9');
+    t.is(data.colors.general.padding, 0);
+    t.is(data.easing, 'easeInOut');
+});
+
 test.after(t => close);

--- a/tests/theme/theme-1.test.js
+++ b/tests/theme/theme-1.test.js
@@ -1,10 +1,6 @@
 const test = require('ava');
 const { close, init } = require('../index');
 
-/*
- * user 2 is an editor who has one chart
- */
-
 test.before(async t => {
     await init();
     const { Theme } = require('../../models');
@@ -15,6 +11,14 @@ test('get theme.data', t => {
     const data = t.context.data;
     t.is(typeof data, 'object');
     t.is(data.colors.general.background, '#f9f9f9');
+});
+
+test('get theme.assets', async t => {
+    const { Theme } = require('../../models');
+    const theme = await Theme.findByPk('datawrapper');
+    t.is(typeof theme.assets, 'object');
+    t.truthy(theme.assets.Roboto);
+    t.falsy(theme.assets.Helvetica);
 });
 
 test('set theme.data', async t => {

--- a/tests/theme/theme-2.test.js
+++ b/tests/theme/theme-2.test.js
@@ -1,0 +1,32 @@
+const test = require('ava');
+const { close, init } = require('../index');
+const { findWhere } = require('underscore');
+
+test.before(async t => {
+    await init();
+    const { getAllMergedThemes } = require('../../utils/theme');
+    t.context = await getAllMergedThemes();
+});
+
+test('get theme.data', t => {
+    const themes = t.context;
+    t.is(themes.length, 14);
+    const theme = findWhere(themes, { id: 'datawrapper-blog' });
+    // check a property coming from the theme itself
+    t.is(theme.data.colors.general.background, '#f9f9f9');
+    // check a property coming from parent theme "datawrapper"
+    t.is(theme.data.colors.general.padding, 0);
+    // check a property coming from grand-parents theme "default"
+    t.is(theme.data.easing, 'easeInOut');
+});
+
+test('get theme.assets', t => {
+    const themes = t.context;
+    t.is(themes.length, 14);
+    const theme = findWhere(themes, { id: 'datawrapper-blog' });
+    // check a property coming from the theme itself
+    t.truthy(theme.assets.Roboto);
+    t.truthy(theme.assets.Helvetica);
+});
+
+test.after(t => close);

--- a/utils/theme.js
+++ b/utils/theme.js
@@ -1,0 +1,43 @@
+const Theme = require('../models/Theme');
+const assign = require('assign-deep');
+const { indexBy } = require('underscore');
+
+/**
+ * in some scenarios it might not be efficient to query themes
+ * with all their parent data individually as some themes would
+ * get queried multiple times.
+ * this implementation provides a single-query alternative by
+ * loading all themes first and then using them to resolve the
+ * theme data dependencies.
+ */
+module.exports.getAllMergedThemes = async function() {
+    const themes = await Theme.findAll();
+    const themesById = indexBy(themes, 'id');
+    const out = [];
+    for (let i = 0; i < themes.length; i++) {
+        let theme = themes[i];
+        const data = [];
+        const assets = [];
+        const less = [];
+        do {
+            data.push(theme.get('data'));
+            if (theme.assets) assets.push(theme.assets);
+            if (theme.less) less.push(theme.less);
+            theme = themesById[theme.get('extend')];
+        } while (theme);
+        let mergedData = {};
+        while (data.length) {
+            mergedData = assign(mergedData, data.pop());
+        }
+        let mergedAssets = {};
+        while (assets.length) {
+            mergedAssets = assign(mergedAssets, assets.pop());
+        }
+        theme = themes[i].toJSON();
+        theme.data = mergedData;
+        theme.assets = mergedAssets;
+        theme.less = less.reverse().join('\n\n');
+        out.push(theme);
+    }
+    return out;
+};

--- a/utils/theme.js
+++ b/utils/theme.js
@@ -31,7 +31,7 @@ module.exports.getAllMergedThemes = async function() {
         }
         let mergedAssets = {};
         while (assets.length) {
-            mergedAssets = assign(mergedAssets, assets.pop());
+            mergedAssets = Object.assign(mergedAssets, assets.pop());
         }
         theme = themes[i].toJSON();
         theme.data = mergedData;


### PR DESCRIPTION
* added getter and setter methods for `theme.data` which is a JSON object stored in a TEXT column. the getter will automatically parse the JSON and the setter will stringify the value.
* likewise, I added getter and setter methods for `theme.assets`
* added `theme.getMergedData` for retrieving "flattened" theme data, which is the theme data with all data of "extended" themes merged into it
* added `theme.getMergedAssets` for retrieving all combined theme assets
* added new helper function `getAllMergedThemes()` to `@datawrapper/orm/utils/theme`. I thought it might be best to put utility functions that are exclusively for getting or setting data using the ORM into the `orm/utils` folder (instead of `@datawrapper/shared`). let me know if you have objections.
* added tests for the above
