### PR TITLE
add logAction util function

### DIFF
--- a/tests/action/action.test.js
+++ b/tests/action/action.test.js
@@ -18,7 +18,7 @@ test('log a new action', async t => {
     res = await logAction(user, 'orm-test/run', 123);
     t.is(res.details, 123);
 
-    res = await logAction(user, 'orm-test/run', 'a string');
+    res = await logAction(2, 'orm-test/run', 'a string');
     t.is(res.details, 'a string');
 
     res = await logAction(user, 'orm-test/run', true);

--- a/tests/action/action.test.js
+++ b/tests/action/action.test.js
@@ -1,0 +1,37 @@
+const test = require('ava');
+const { close, init } = require('../index');
+
+test.before(async t => {
+    await init();
+    const { Action, User } = require('../../models');
+    const { logAction } = require('../../utils/action');
+    const user = await User.findByPk(1);
+    t.context = { Action, logAction, user };
+});
+
+test('log a new action', async t => {
+    const { logAction, Action, user } = t.context;
+
+    let res = await logAction(user, 'orm-test/run');
+    t.is(res.key, 'orm-test/run');
+
+    res = await logAction(user, 'orm-test/run', 123);
+    t.is(res.details, 123);
+
+    res = await logAction(user, 'orm-test/run', 'a string');
+    t.is(res.details, 'a string');
+
+    res = await logAction(user, 'orm-test/run', true);
+    t.is(res.details, 'true');
+
+    res = await logAction(user, 'orm-test/run', { foo: 'bar' });
+    t.is(res.details, '{"foo":"bar"}');
+
+    await Action.destroy({
+        where: {
+            key: 'orm-test/run'
+        }
+    });
+});
+
+test.after(t => close);

--- a/utils/action.js
+++ b/utils/action.js
@@ -1,0 +1,19 @@
+const Action = require('../models/Action');
+
+/**
+ * helper for logging a user action to the `action` table
+ *
+ * @param {object} user
+ * @param {string} key
+ * @param {*} details
+ */
+module.exports.logAction = async function(user, key, details) {
+    const action = await Action.create({
+        key: key,
+        details:
+            typeof details !== 'number' && typeof details !== 'string'
+                ? JSON.stringify(details)
+                : details
+    });
+    return action.setUser(user);
+};

--- a/utils/action.js
+++ b/utils/action.js
@@ -3,9 +3,9 @@ const Action = require('../models/Action');
 /**
  * helper for logging a user action to the `action` table
  *
- * @param {object} user
- * @param {string} key
- * @param {*} details
+ * @param {object|integer} user - user_id or User instance object
+ * @param {string} key - the action key
+ * @param {*} details - action details
  */
 module.exports.logAction = async function(user, key, details) {
     const action = await Action.create({


### PR DESCRIPTION
this PR adds a orm util function `logAction` for, well, logging user actions to our `actions` table. It's more or less a straight port of our old `Action::logAction()` function [in PHP](https://github.com/datawrapper/datawrapper/blob/master/lib/core/build/classes/datawrapper/Action.php#L18-L31).