### PR TITLE
feat: plugin functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,49 @@ Note that this will initialize the entire model, which assumes that your databas
 ```js
 const User = require('@datawrapper/orm/models/User');
 ```
+
+### Plugins
+
+The ORMs functionality can be extended with plugins. This is needed, for example, when new database tables are needed. The plugin API follows the convention of plugins in [datawrapper/api](https://github.com/datawrapper/api#plugins).
+
+A simple ORM plugin that does nothing looks like this:
+
+```js
+/* config.js */
+plugins: {
+    'my-orm-plugin': {
+        my_name: 'Steve'
+    }
+}
+
+/* orm.js */
+module.exports = {
+    register: async (ORM, config) => {
+        console.log(`Hi I am ${config.my_name}!`)
+        // logs "Hi I am Steve!" on registration
+    }
+}
+```
+
+There are 2 interesting properties on the `ORM` object that help with plugin access.
+
+* `ORM.plugins` is an object with all configured plugins. They are **not** registered by default. Since standard `Models` are not defined after `ORM.init()` either, it wouldn't make sense to do that for plugins.
+
+This is how you register a plugin:
+
+```js
+await ORM.init()
+const { plugins } = ORM
+
+const MyORMPlugin = require(plugins['my-orm-plugin'].requirePath)
+await MyORMPlugin.register(ORM, plugins['my-orm-plugin'])
+```
+
+This method is very useful for tests where you only need a special plugin. There is also a helper method to register all plugins. It is in functionality similar to requiring all models with `require('@datawrapper/orm/models')`.
+
+* `ORM.registerPlugins` will register all plugins.
+
+```js
+await ORM.init()
+await ORM.registerPlugins()
+```

--- a/index.js
+++ b/index.js
@@ -1,59 +1,64 @@
 /* globals process */
 
 const Sequelize = require('sequelize');
+const { findPlugins, createRegisterPlugins } = require('./utils/plugins');
+
+let retries = 0;
 
 const ORM = {
-    init(config) {
+    async init(config) {
         const dbConfig = config.orm && config.orm.db ? config.orm.db : config.db;
+        let configuredPlugins = {};
 
-        return new Promise((resolve, reject) => {
-            connect();
-            /**
-             * attempts to initialize the ORM. if it fails and
-             * `config.orm.retry`` is true, it will retry connecting after
-             * 10 seconds.
-             */
-            function connect() {
-                const sequelize = new Sequelize(
-                    dbConfig.database,
-                    dbConfig.user,
-                    dbConfig.password,
-                    {
-                        host: dbConfig.host,
-                        port: dbConfig.port,
-                        dialect: dbConfig.dialect,
-                        logging: process.env.DEV ? s => process.stdout.write(s + '\n') : false,
-                        define: {
-                            timestamps: true,
-                            updatedAt: false,
-                            underscored: true
-                        }
+        if (config.general && config.general.localPluginRoot && config.plugins) {
+            configuredPlugins = await findPlugins(config.general.localPluginRoot, config.plugins);
+        }
+
+        /**
+         * attempts to initialize the ORM. if it fails and
+         * `config.orm.retry`` is true, it will retry connecting after
+         * 10 seconds.
+         */
+        async function connect() {
+            const sequelize = new Sequelize(dbConfig.database, dbConfig.user, dbConfig.password, {
+                host: dbConfig.host,
+                port: dbConfig.port,
+                dialect: dbConfig.dialect,
+                logging: process.env.DEV ? s => process.stdout.write(s + '\n') : false,
+                define: {
+                    timestamps: true,
+                    updatedAt: false,
+                    underscored: true
+                }
+            });
+
+            try {
+                await sequelize.query('select id from chart limit 1');
+                ORM.db = sequelize;
+                ORM.db.Op = Sequelize.Op;
+                ORM.db.Sequelize = Sequelize;
+                ORM.token_salt = config.secure_auth_salt || '';
+                ORM.plugins = configuredPlugins;
+                ORM.registerPlugins = createRegisterPlugins(ORM, configuredPlugins);
+            } catch (err) {
+                if (err.name.substr(0, 9) === 'Sequelize' && config.orm && config.orm.retry) {
+                    console.warn(err.message);
+                    console.warn('database is not ready, yet. retrying in 3 seconds...');
+                    if (retries < 4) {
+                        retries++;
+                        await wait(connect, 3000);
+                    } else {
+                        throw err;
                     }
-                );
-
-                sequelize
-                    .query('select id from chart limit 1')
-                    .then(() => {
-                        ORM.db = sequelize;
-                        ORM.db.Op = Sequelize.Op;
-                        ORM.token_salt = config.secure_auth_salt || '';
-                        resolve();
-                    })
-                    .catch(err => {
-                        if (
-                            err.name.substr(0, 9) === 'Sequelize' &&
-                            config.orm &&
-                            config.orm.retry
-                        ) {
-                            console.warn(err.message);
-                            console.warn('database is not ready, yet. retrying in 10 seconds...');
-                            setTimeout(connect, 3000);
-                        } else {
-                            reject(err);
-                        }
-                    });
+                } else {
+                    throw err;
+                }
             }
-        });
+
+            return ORM;
+        }
+
+        return connect();
     },
     db: {
         define() {
@@ -64,3 +69,15 @@ const ORM = {
 };
 
 module.exports = ORM;
+
+function wait(f, ms) {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => {
+            try {
+                resolve(f());
+            } catch (error) {
+                reject(error);
+            }
+        }, ms);
+    });
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "scripts": {
         "format": "prettier 'models/**/*.js' --write",
         "lint": "prettier --check 'models/**/*.{js,html}' && healthier 'models/**/*.{js,html}'",
-        "test": "ava"
+        "test": "ava --verbose"
     },
     "repository": {
         "type": "git",

--- a/plugins/orm-test/orm.js
+++ b/plugins/orm-test/orm.js
@@ -1,0 +1,20 @@
+const SQ = require('sequelize');
+
+module.exports = {
+    register: async (ORM, config) => {
+        const ORMTest = ORM.db.define('orm_test', {
+            id: {
+                type: SQ.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+
+            data: {
+                type: SQ.STRING(),
+                field: 'value'
+            }
+        });
+        await ORMTest.sync();
+        return ORMTest;
+    }
+};

--- a/tests/config.ci.js
+++ b/tests/config.ci.js
@@ -1,4 +1,12 @@
+const path = require('path');
 module.exports = {
+    general: {
+        localPluginRoot: path.resolve(path.join(process.cwd(), 'plugins'))
+    },
+    plugins: {
+        'orm-test': {},
+        lul: {}
+    },
     orm: {
         db: {
             dialect: 'mysql',

--- a/tests/plugin-loader/plugin-loader.test.js
+++ b/tests/plugin-loader/plugin-loader.test.js
@@ -1,0 +1,49 @@
+const test = require('ava');
+const { close, init } = require('../index');
+
+test.beforeEach(async t => {
+    t.context.ORM = await init();
+});
+
+test.serial('"orm-test" plugin registration', async t => {
+    const { plugins } = t.context.ORM;
+
+    t.truthy(plugins['orm-test']);
+    t.log('"orm-test" is available');
+
+    const TestPlugin = require(plugins['orm-test'].requirePath);
+    const ORMTest = await TestPlugin.register(t.context.ORM);
+
+    t.is(t.context.ORM.db.models.orm_test, ORMTest);
+    t.log('"orm-test" is registered');
+
+    const row = await ORMTest.create({ data: 'Test' });
+
+    t.truthy(row.id);
+    t.is(row.data, 'Test');
+    t.log('"orm-test" can write data');
+
+    await row.destroy();
+    await ORMTest.drop();
+    t.log('"orm-test" removed');
+});
+
+test.serial('ORM.registerPlugins registers all plugins', async t => {
+    const { registerPlugins, plugins } = t.context.ORM;
+    await registerPlugins();
+
+    t.is(typeof t.context.ORM.db.models.orm_test, 'function');
+    t.is(Object.keys(plugins).length, Object.keys(t.context.ORM.db.models).length);
+
+    const ORMTest = t.context.ORM.db.models.orm_test;
+
+    const row = await ORMTest.create({ data: 'Test-2' });
+
+    t.truthy(row.id);
+    t.is(row.data, 'Test-2');
+
+    await row.destroy();
+    await ORMTest.drop();
+});
+
+test.after(t => close);

--- a/utils/plugins.js
+++ b/utils/plugins.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+const stat = promisify(fs.stat);
+
+async function findPlugins(localPluginRoot, dwPlugins) {
+    const plugins = {};
+    for (const plugin of Object.entries(dwPlugins)) {
+        try {
+            const requirePath = path.resolve(localPluginRoot, plugin[0], 'orm.js');
+
+            await stat(requirePath);
+            plugins[plugin[0]] = plugin[1];
+            plugins[plugin[0]].requirePath = requirePath;
+        } catch (error) {}
+    }
+
+    return plugins;
+}
+
+function createRegisterPlugins(ORM, plugins) {
+    return async function registerPlugins() {
+        for (const [name, config] of Object.entries(plugins)) {
+            const Plugin = require(plugins[name].requirePath);
+            await Plugin.register(ORM, config);
+        }
+    };
+}
+
+module.exports = { findPlugins, createRegisterPlugins };


### PR DESCRIPTION
Plugins are at the core of Datawrapper and following `datawrapper/api` and to some degree `datawrapper/frontend` the ORM gets them too.

The plugin API for the ORM closely follows what is done for `datawrapper/api`. 

* create a `orm.js` that exports a node module with a `register` method
* enable the plugin by adding it to `config.js`
* register plugin in your code.

This PR includes an example plugin, tests for the plugin loader and documentation.

After merging this PR we can build the basic River functionality for the new rendering pipeline.