### PR TITLE
Don't limit db connection retries unless configured

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ const ORM = {
                 if (err.name.substr(0, 9) === 'Sequelize' && config.orm && config.orm.retry) {
                     console.warn(err.message);
                     console.warn(
-                        `database is not ready, yet. retrying in ${retryInterval} seconds...`
+                        `database is not ready, yet. retrying in ${retryInterval / 1000} seconds...`
                     );
                     if (!config.orm.retryLimit || retries < config.orm.retryLimit) {
                         retries++;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ let retries = 0;
 const ORM = {
     async init(config) {
         const dbConfig = config.orm && config.orm.db ? config.orm.db : config.db;
+        const retryTimeout = config.orm.retryTimeout ? config.orm.retryTimeout * 1000 : 3000;
+
         let configuredPlugins = {};
 
         if (config.general && config.general.localPluginRoot && config.plugins) {
@@ -43,10 +45,12 @@ const ORM = {
             } catch (err) {
                 if (err.name.substr(0, 9) === 'Sequelize' && config.orm && config.orm.retry) {
                     console.warn(err.message);
-                    console.warn('database is not ready, yet. retrying in 3 seconds...');
-                    if (retries < 4) {
+                    console.warn(
+                        `database is not ready, yet. retrying in ${retryTimeout} seconds...`
+                    );
+                    if (!config.orm.retryLimit || retries < config.orm.retryLimit) {
                         retries++;
-                        await wait(connect, 3000);
+                        await wait(connect, retryTimeout);
                     } else {
                         throw err;
                     }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ let retries = 0;
 const ORM = {
     async init(config) {
         const dbConfig = config.orm && config.orm.db ? config.orm.db : config.db;
-        const retryTimeout = config.orm.retryTimeout ? config.orm.retryTimeout * 1000 : 3000;
+        const retryInterval = config.orm.retryInterval ? config.orm.retryInterval * 1000 : 3000;
 
         let configuredPlugins = {};
 
@@ -46,11 +46,11 @@ const ORM = {
                 if (err.name.substr(0, 9) === 'Sequelize' && config.orm && config.orm.retry) {
                     console.warn(err.message);
                     console.warn(
-                        `database is not ready, yet. retrying in ${retryTimeout} seconds...`
+                        `database is not ready, yet. retrying in ${retryInterval} seconds...`
                     );
                     if (!config.orm.retryLimit || retries < config.orm.retryLimit) {
                         retries++;
-                        await wait(connect, retryTimeout);
+                        await wait(connect, retryInterval);
                     } else {
                         throw err;
                     }


### PR DESCRIPTION
When the database connection is created when initializing the ORM, it retries after a certain period if the db connect attempt was unsuccessful. Before the introduction of [orm plugins](https://github.com/datawrapper/orm/pull/9), this interval was **10 seconds**, and it retried **indefinitely**. Now, it's every **3 seconds**, and only up to **4 tries** before it throws an error. 

This gives the database 12 seconds to come up, which can be too short. I noticed this in the docker environment where all containers are started at the same time, and an initial start of a mySQL container can take a while for the database to initialize. This PR changes the behavior in the following ways:
- ORM retries to connect indefinitely, unless `config.orm.retryLimit` is set
- ORM retries every 3 seconds, unless `config.orm.retryInterval` is set

I'm not sure in which scenarios a `retryLimit` is desirable, and we don't have a corresponding option for the PHP app. But in case we want it, it should be configurable.