### PR TITLE
fix infinite recursion bug when accessing userteam.team_role

### DIFF
--- a/models/UserTeam.js
+++ b/models/UserTeam.js
@@ -10,9 +10,8 @@ const UserTeam = db.define(
             allowNull: false,
             defaultValue: 'member',
             get() {
-                const { team_role } = this.get();
-                // const teamRole = this.getDataValue('team_role');
-                return this.rawAttributes.team_role.values[team_role];
+                const teamRole = this.getDataValue('team_role');
+                return this.rawAttributes.team_role.values[teamRole];
             },
             set(val) {
                 if (typeof val === 'string') {


### PR DESCRIPTION
This PR fixes an error I caught a couple of times:
```
RangeError: Maximum call stack size exceeded
	at Object.hasOwnProperty (<anonymous>)
	at model.get (/app/node_modules/sequelize/lib/model.js:3363:35)
	at model.get (/app/node_modules/@datawrapper/orm/models/UserTeam.js:13:44)
	at model.get (/app/node_modules/sequelize/lib/model.js:3330:41)
	at model.get (/app/node_modules/sequelize/lib/model.js:3364:33)
	at model.get (/app/node_modules/@datawrapper/orm/models/UserTeam.js:13:44)
	at model.get (/app/node_modules/sequelize/lib/model.js:3330:41)
	at model.get (/app/node_modules/sequelize/lib/model.js:3364:33)
	at model.get (/app/node_modules/@datawrapper/orm/models/UserTeam.js:13:44)
	at model.get (/app/node_modules/sequelize/lib/model.js:3330:41)
	at model.get (/app/node_modules/sequelize/lib/model.js:3364:33)
	at model.get (/app/node_modules/@datawrapper/orm/models/UserTeam.js:13:44)
	at model.get (/app/node_modules/sequelize/lib/model.js:3330:41)
	at model.get (/app/node_modules/sequelize/lib/model.js:3364:33)
	at model.get (/app/node_modules/@datawrapper/orm/models/UserTeam.js:13:44)
	at model.get (/app/node_modules/sequelize/lib/model.js:3330:41)
	at model.get (/app/node_modules/sequelize/lib/model.js:3364:33)
	at model.get (/app/node_modules/@datawrapper/orm/models/UserTeam.js:13:44)
	at model.get (/app/node_modules/sequelize/lib/model.js:3330:41)
	at model.get (/app/node_modules/sequelize/lib/model.js:3364:33)
	at model.get (/app/node_modules/@datawrapper/orm/models/UserTeam.js:13:44)
	at model.get (/app/node_modules/sequelize/lib/model.js:3330:41)
```
