### PR TITLE
set sequelize dependency to 6.0.0-beta-4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -833,9 +833,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha1-fQHG+WFsmlGrD4xUmnnf5uwz76c="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "blueimp-md5": {
       "version": "2.12.0",
@@ -1438,7 +1438,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -1638,9 +1637,9 @@
       }
     },
     "dottie": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.1.tgz",
-      "integrity": "sha512-ch5OQgvGDK2u8pSZeSYAQaV/lczImd7pMJ7BcEPXmnFVjy4yJIzP6CsODJUTH8mg1tyH1Z2abOiuJO3DjZ/GBw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
+      "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -4186,9 +4185,9 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-timezone": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.25.tgz",
-      "integrity": "sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==",
+      "version": "0.5.27",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.27.tgz",
+      "integrity": "sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==",
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -5138,7 +5137,8 @@
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha1-fnQlb7qknHWqfHogXMInmcrIAAQ="
+      "integrity": "sha1-fnQlb7qknHWqfHogXMInmcrIAAQ=",
+      "dev": true
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -5161,40 +5161,37 @@
       "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
     },
     "sequelize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.0.0.tgz",
-      "integrity": "sha512-MNgSS7aSy49KLtTMduUzFuwY2SQDtgSY1t7l+5+se4HTGxh+/RwaJHPI3CsGZMgEc8wQZ+r4xBCUkekoSgqJmg==",
+      "version": "6.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.0.0-beta.4.tgz",
+      "integrity": "sha512-p0CzKCWumVSkQJj13/17iIt7MAwo3IBgn3FLdoJ2dizvBa9uRtprI6XTmBKvK0NjqHXK+cBDZUpPR1J+NMeAJw==",
       "requires": {
-        "bluebird": "^3.5.0",
+        "bluebird": "^3.7.1",
         "debug": "^4.1.1",
         "dottie": "^2.0.0",
         "inflection": "1.12.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "moment": "^2.24.0",
         "moment-timezone": "^0.5.21",
-        "retry-as-promised": "^3.1.0",
-        "semver": "^5.6.0",
-        "sequelize-pool": "^2.1.0",
+        "retry-as-promised": "^3.2.0",
+        "semver": "^6.3.0",
+        "sequelize-pool": "^2.3.0",
         "toposort-class": "^1.0.1",
-        "uuid": "^3.2.1",
+        "uuid": "^3.3.3",
         "validator": "^10.11.0",
-        "wkx": "^0.4.6"
+        "wkx": "^0.4.8"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
     "sequelize-pool": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.2.0.tgz",
-      "integrity": "sha512-N/cYyxNHShfANGXAhHtMExjWNr+eYCS4/pF5fs5fvPYxn1VgUhEX8kDmVV5bNS0gZwt55fjU9Sgg48k3Dy/uMg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
+      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA=="
     },
     "serialize-error": {
       "version": "2.1.0",
@@ -5848,9 +5845,9 @@
       }
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -5934,9 +5931,9 @@
       }
     },
     "wkx": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.7.tgz",
-      "integrity": "sha512-pHf546L96TK8RradLt1cWaIffstgv/zXZ14CGz5KnBs1AxBX0wm+IDphjJw0qrEqRv8P9W9CdTt8Z1unMRZ19A==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
+      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "merge-deep": "^3.0.2",
         "mysql2": "1.7.0",
         "nanoid": "2.1.6",
-        "sequelize": "6.0.0",
+        "sequelize": "6.0.0-beta.4",
         "underscore": "1.9.1"
     },
     "devDependencies": {

--- a/tests/theme/theme-1.test.js
+++ b/tests/theme/theme-1.test.js
@@ -22,15 +22,16 @@ test('get theme.assets', async t => {
 });
 
 test('set theme.data', async t => {
-    let theme = t.context;
-    const data = theme.get('data');
+    const theme = t.context;
+    const data = theme.data;
+    // font size in db is 13
+    t.is(theme.data.typography.chart.fontSize, 13);
 
     // set fontsize to 15
-    data.typography.chart.fontSize = 15;
-    theme.set('data', data);
+    theme.set('data.typography.chart.fontSize', 15);
 
     // check if local data is ok
-    t.is(theme.get('data').typography.chart.fontSize, 15);
+    t.is(theme.data.typography.chart.fontSize, 15);
 
     // save change to DB
     await theme.save();
@@ -40,8 +41,7 @@ test('set theme.data', async t => {
     t.is(theme.data.typography.chart.fontSize, 15);
 
     // reset value to 13
-    data.typography.chart.fontSize = 13;
-    theme.set('data', data);
+    theme.set('data.typography.chart.fontSize', 13);
     await theme.save();
     await theme.reload();
     t.is(theme.data.typography.chart.fontSize, 13);


### PR DESCRIPTION
sequelize 6.0.0 has been published accidentally and is now no longer available via `npm`. 

see https://github.com/sequelize/sequelize/issues/11485 for more details