### PR TITLE
fix: add chart_id to model

### DIFF
--- a/models/ChartAccessToken.js
+++ b/models/ChartAccessToken.js
@@ -16,7 +16,8 @@ const ChartAccessToken = db.define(
             autoIncrement: true
         },
 
-        token: SQ.STRING(128)
+        token: SQ.STRING(128),
+        chart_id: SQ.STRING(5)
     },
     {
         tableName: 'chart_access_token'


### PR DESCRIPTION
I tried running the render network locally and saw that rows in `chart_access_token` where written without `chart_id`. This caused the render-client to fail. With this little addition, it's fixed.