### PR TITLE
Add missing relation fields

### DIFF
--- a/models/AccessToken.js
+++ b/models/AccessToken.js
@@ -34,6 +34,6 @@ AccessToken.newToken = async function({ user_id, type, data }) {
 };
 
 const User = require('./User');
-AccessToken.belongsTo(User);
+AccessToken.belongsTo(User, { foreignKey: 'user_id' });
 
 module.exports = AccessToken;

--- a/models/AuthToken.js
+++ b/models/AuthToken.js
@@ -15,7 +15,6 @@ const AuthToken = db.define(
             primaryKey: true,
             autoIncrement: true
         },
-        user_id: SQ.INTEGER,
         token: SQ.STRING(128),
         comment: SQ.STRING(255),
         last_used_at: SQ.DATE
@@ -35,6 +34,6 @@ AuthToken.newToken = async function({ user_id, comment }) {
 };
 
 const User = require('./User');
-AuthToken.belongsTo(User);
+AuthToken.belongsTo(User, { foreignKey: 'user_id' });
 
 module.exports = AuthToken;

--- a/models/ChartAccessToken.js
+++ b/models/ChartAccessToken.js
@@ -5,7 +5,7 @@ const generate = require('nanoid/generate');
 const alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
 /*
- * this model is deprecated, we'll switch to AccessToken soons
+ * this model is deprecated, we'll switch to AccessToken some day
  */
 const ChartAccessToken = db.define(
     'chart_access_token',

--- a/models/ChartAccessToken.js
+++ b/models/ChartAccessToken.js
@@ -16,8 +16,7 @@ const ChartAccessToken = db.define(
             autoIncrement: true
         },
 
-        token: SQ.STRING(128),
-        chart_id: SQ.STRING(5)
+        token: SQ.STRING(128)
     },
     {
         tableName: 'chart_access_token'
@@ -33,6 +32,6 @@ ChartAccessToken.newToken = async function({ chart_id }) {
 };
 
 const Chart = require('./Chart');
-ChartAccessToken.belongsTo(Chart);
+ChartAccessToken.belongsTo(Chart, { foreignKey: 'chart_id' });
 
 module.exports = ChartAccessToken;

--- a/models/ExportJob.js
+++ b/models/ExportJob.js
@@ -33,11 +33,7 @@ const ExportJob = db.define(
         // a log file with debug and error messages from the client
         // should not be tampered with manually, instead please use
         // job.logProgress()
-        log: SQ.JSON,
-
-        user_id: SQ.INTEGER,
-
-        chart_id: SQ.STRING(5)
+        log: SQ.JSON
     },
     {
         tableName: 'export_job'
@@ -72,7 +68,7 @@ ExportJob.prototype.logProgress = async function(info) {
 const User = require('./User');
 const Chart = require('./Chart');
 
-ExportJob.belongsTo(User);
-ExportJob.belongsTo(Chart);
+ExportJob.belongsTo(User, { foreignKey: 'user_id' });
+ExportJob.belongsTo(Chart, { foreignKey: 'chart_id' });
 
 module.exports = ExportJob;

--- a/models/PluginData.js
+++ b/models/PluginData.js
@@ -25,7 +25,7 @@ const PluginData = db.define(
 
 const Plugin = require('./Plugin');
 
-PluginData.belongsTo(Plugin);
+PluginData.belongsTo(Plugin, { foreignKey: 'plugin_id' });
 Plugin.hasMany(PluginData, { as: 'PluginData' });
 
 module.exports = PluginData;

--- a/models/UserData.js
+++ b/models/UserData.js
@@ -28,7 +28,7 @@ const UserData = db.define(
 
 const User = require('./User');
 
-UserData.belongsTo(User);
+UserData.belongsTo(User, { foreignKey: 'user_id' });
 User.hasMany(UserData, { as: 'UserData' });
 
 module.exports = UserData;

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -1,10 +1,10 @@
 const test = require('ava');
-const { close, init } = require('../index');
+const { close, init } = require('./index');
 
 test.before(async t => {
     await init();
-    const { Action, User } = require('../../models');
-    const { logAction } = require('../../utils/action');
+    const { Action, User } = require('../models');
+    const { logAction } = require('../utils/action');
     const user = await User.findByPk(1);
     t.context = { Action, logAction, user };
 });
@@ -17,9 +17,11 @@ test('log a new action', async t => {
 
     res = await logAction(user.id, 'orm-test/run', 123);
     t.is(res.details, 123);
+    t.is(res.user_id, user.id);
 
     res = await logAction(2, 'orm-test/run', 'a string');
     t.is(res.details, 'a string');
+    t.is(res.user_id, 2);
 
     res = await logAction(user.id, 'orm-test/run', true);
     t.is(res.details, 'true');

--- a/tests/authToken.test.js
+++ b/tests/authToken.test.js
@@ -1,0 +1,31 @@
+const test = require('ava');
+const { close, init } = require('./index');
+
+test.before(async t => {
+    await init();
+    const { AuthToken, User } = require('../models');
+    const user = await User.findByPk(1);
+    t.context = { AuthToken, user };
+});
+
+test('log a new AuthToken', async t => {
+    const { AuthToken, user } = t.context;
+
+    const res = await AuthToken.newToken({
+        user_id: user.id,
+        comment: 'orm-test/run'
+    });
+
+    t.is(res.comment, 'orm-test/run');
+    t.is(typeof res.token, 'string');
+    t.is(res.token.length, 32);
+    t.is(res.user_id, user.id);
+
+    await AuthToken.destroy({
+        where: {
+            key: 'orm-test/run'
+        }
+    });
+});
+
+test.after(t => close);

--- a/tests/authToken.test.js
+++ b/tests/authToken.test.js
@@ -23,7 +23,7 @@ test('log a new AuthToken', async t => {
 
     await AuthToken.destroy({
         where: {
-            key: 'orm-test/run'
+            comment: 'orm-test/run'
         }
     });
 });

--- a/tests/chartAccessToken.test.js
+++ b/tests/chartAccessToken.test.js
@@ -1,0 +1,29 @@
+const test = require('ava');
+const { close, init } = require('./index');
+
+test.before(async t => {
+    await init();
+    const { ChartAccessToken, User } = require('../models');
+    const user = await User.findByPk(1);
+    t.context = { ChartAccessToken, user };
+});
+
+test('create a new ChartAccessToken', async t => {
+    const { ChartAccessToken, user } = t.context;
+
+    const res = await ChartAccessToken.newToken({
+        chart_id: 'aaaaa'
+    });
+
+    t.is(typeof res.token, 'string');
+    t.is(res.token.length, 32);
+    t.is(res.chart_id, 'aaaaa');
+
+    await ChartAccessToken.destroy({
+        where: {
+            token: res.token
+        }
+    });
+});
+
+test.after(t => close);

--- a/tests/export-job.test.js
+++ b/tests/export-job.test.js
@@ -1,5 +1,5 @@
 const test = require('ava');
-const { close, init } = require('../index');
+const { close, init } = require('./index');
 
 /**
  * test creates a new dummy ExportJob instance and tests the job.process()
@@ -8,7 +8,7 @@ const { close, init } = require('../index');
 
 test.before(async t => {
     await init();
-    const { ExportJob } = require('../../models');
+    const { ExportJob } = require('../models');
     // create new test job
     t.context = await ExportJob.create({
         key: 'test-task',
@@ -41,7 +41,7 @@ test('log progress', async t => {
     t.is(typeof t.context.log.progress, 'object');
     t.is(t.context.log.progress.length, 1);
     t.is(t.context.log.progress[0].message, 'foo');
-    t.truthy(Date.prototype.isPrototypeOf(t.context.log.progress[0].timestamp));
+    t.truthy(t.context.log.progress[0].timestamp instanceof Date);
     await t.context.logProgress({ message: 'another message' });
     t.is(t.context.log.progress.length, 2);
 });

--- a/tests/export-job.test.js
+++ b/tests/export-job.test.js
@@ -11,6 +11,8 @@ test.before(async t => {
     const { ExportJob } = require('../models');
     // create new test job
     t.context = await ExportJob.create({
+        chart_id: 'aaaaa',
+        user_id: 1,
         key: 'test-task',
         created_at: new Date(),
         status: 'queued',
@@ -30,6 +32,8 @@ test('process task', async t => {
     await t.context.process();
     t.is(typeof t.context.log, 'object');
     t.is(t.context.log.attempts, 1);
+    t.is(t.context.user_id, 1);
+    t.is(t.context.chart_id, 'aaaaa');
     // one more process attempt
     await t.context.process();
     t.is(t.context.log.attempts, 2);

--- a/tests/pluginData.test.js
+++ b/tests/pluginData.test.js
@@ -1,0 +1,48 @@
+const test = require('ava');
+const { close, init } = require('./index');
+
+test.before(async t => {
+    await init();
+    const { PluginData, Plugin } = require('../models');
+    const plugin = await Plugin.findByPk('hello-world');
+    t.context = { PluginData, Plugin, plugin };
+});
+
+test('create a new ChartAccessToken', async t => {
+    const { PluginData, Plugin, plugin } = t.context;
+
+    const res = await PluginData.create({
+        plugin_id: plugin.id,
+        stored_at: new Date(),
+        key: 'orm-test',
+        data: 'It works'
+    });
+
+    t.is(res.plugin_id, plugin.id);
+    t.is(res.key, 'orm-test');
+    t.is(res.data, 'It works');
+    t.true(res.stored_at instanceof Date);
+
+    // store another one
+    const res2 = await PluginData.create({
+        plugin_id: plugin.id,
+        stored_at: new Date(),
+        key: 'orm-test',
+        data: 'It worked again'
+    });
+
+    // load plugin data
+    const pd = await plugin.getPluginData();
+    t.is(pd.length, 2);
+    t.is(pd[0].key, 'orm-test');
+    t.is(pd[0].plugin_id, plugin.id);
+    t.is(pd[1].plugin_id, plugin.id);
+
+    await PluginData.destroy({
+        where: {
+            key: 'orm-test'
+        }
+    });
+});
+
+test.after(t => close);

--- a/tests/team.test.js
+++ b/tests/team.test.js
@@ -1,5 +1,5 @@
 const test = require('ava');
-const { close, init } = require('../index');
+const { close, init } = require('./index');
 
 /*
  * user 2 is an editor who has one chart
@@ -7,7 +7,7 @@ const { close, init } = require('../index');
 
 test.before(async t => {
     await init();
-    const { Team } = require('../../models');
+    const { Team } = require('../models');
     t.context = await Team.findByPk('team-1');
 });
 

--- a/tests/userData.test.js
+++ b/tests/userData.test.js
@@ -1,5 +1,5 @@
 const test = require('ava');
-const { close, init } = require('../index');
+const { close, init } = require('./index');
 
 /*
  * user 1 is an admin who does not have anything
@@ -8,7 +8,7 @@ const { close, init } = require('../index');
 
 test.before(async t => {
     await init();
-    const userData = require('../../utils/userData');
+    const userData = require('../utils/userData');
     t.context = userData;
 });
 


### PR DESCRIPTION
Some `sequelize` update has led to a change in behavior regarding to models that aren't completely defined. Fields that were missing in the model definition could still be set or updated in Sequelize queries. The current version of Sequelize requires defining all fields, either as model fields or as `foreignKeys` in a `belongsTo` relation.

This PR adds all the missing `foreignKey`s and some tests to confirm the values are actually set.