### PR TITLE
Fix object serialization in Session.js

### DIFF
--- a/models/Session.js
+++ b/models/Session.js
@@ -135,7 +135,7 @@ function phpSerialize(mixedValue) {
 
             for (key in mixedValue) {
                 /* https://eslint.org/docs/rules/no-prototype-builtins */
-                if (Object.prototype.hasOwnProperty.call(hasOwnProperty, key)) {
+                if (Object.prototype.hasOwnProperty.call(mixedValue, key)) {
                     ktype = _getType(mixedValue[key]);
                     if (ktype === 'function') {
                         continue;


### PR DESCRIPTION
This PR fixes a bug that caused objects in the `session.data` column to not get serialized and instead being set to null, leading to various problem down the road regarding sessions with third-party sign-in providers.

I think this was simply an oversight when doing some refactoring to please eslint (https://github.com/datawrapper/orm/commit/135e8eac2ab79dba53ac6e98dc12ffa06057f49e#diff-c85e4fa0da25cc36124a84aa26ca5927R138)