### PR TITLE
add optional user_id column to session table

### DIFF
--- a/models/Session.js
+++ b/models/Session.js
@@ -11,6 +11,11 @@ const Session = db.define(
             field: 'session_id'
         },
 
+        user_id: {
+            type: SQ.INTEGER,
+            allowNull: true
+        },
+
         data: {
             type: SQ.TEXT,
             allowNull: false,

--- a/models/Session.js
+++ b/models/Session.js
@@ -16,6 +16,8 @@ const Session = db.define(
             allowNull: true
         },
 
+        persistent: SQ.BOOLEAN,
+
         data: {
             type: SQ.TEXT,
             allowNull: false,


### PR DESCRIPTION
This PR adds the fields `user_id` and `persistent` to the `Session` model. This will allow us to 

* delete all sessions related to a user
* delete all expired non-persistent sessions

I did omit the Sequelize model relation to `User` on purpose. For now I don't think we should add a foreign key constraint here, both because there are guest sessions without a user and I don't want to hazzle with conflict cases. For now this is just some extra information we're storing to make querying easier.