### PR TITLE
feat: add chart.publicId virtual field

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:10
+    - image: circleci/node:12
 
 cache: &cache
     key: v1-dependency-cache-{{ checksum "package-lock.json" }}
@@ -29,10 +29,10 @@ jobs:
           <<: *cache
 
       - run:
+          name: Tests
           command: |
-            mv tests/config.ci.js tests/config.js
             mkdir -p ~/reports/ava
-            npm test -- --tap | npx tap-xunit > ~/reports/ava/results.xml
+            DW_CONFIG_PATH=tests/config.ci.js npx ava --tap | npx tap-xunit > ~/reports/ava/results.xml
       - store_test_results:
           path: ~/reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,98 +1,59 @@
-defaults: &defaults
-  working_directory: ~/repo
-  docker:
-    - image: circleci/node:12
+version: 2.1
 
-cache: &cache
-    key: v1-dependency-cache-{{ checksum "package-lock.json" }}
+# https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors
+executors:
+    dw-executor:
+        working_directory: ~/repo
+        docker:
+            - image: circleci/node:12
+              environment:
+                  DW_CONFIG_PATH: /home/circleci/repo/tests/config.ci.js
 
-version: 2
+# https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
+commands:
+    restore_npm_cache:
+        description: Restores .npm directory for faster installs
+        steps:
+            - restore_cache:
+                  keys:
+                      - v4-install-cache-{{ checksum "package-lock.json" }}
+                      - v4-install-cache
+
 jobs:
-  install:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache
+    test:
+        executor: dw-executor
+        steps:
+            - checkout
+            - restore_npm_cache
 
-      - run: npm ci
+            - run:
+                  environment:
+                      HUSKY_SKIP_INSTALL: 1
+                  command: npm ci
 
-      - save_cache:
-          <<: *cache
-          paths:
-            - node_modules
-  test:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache
+            - run:
+                  name: Lint code
+                  command: npm run lint
+            - run:
+                  name: Run tests
+                  command: |
+                      mkdir -p ~/reports/ava
+                      npx ava --tap | npx tap-xunit > ~/reports/ava/results.xml
+            - store_test_results:
+                  path: ~/reports
+            - store_artifacts:
+                  path: ~/reports
 
-      - run:
-          name: Tests
-          command: |
-            mkdir -p ~/reports/ava
-            DW_CONFIG_PATH=tests/config.ci.js npx ava --tap | npx tap-xunit > ~/reports/ava/results.xml
-      - store_test_results:
-          path: ~/reports
-      - store_artifacts:
-          path: ~/reports
-
-
-  lint:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache
-
-      - run: npm run lint
-
-  publish:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache
-
-      - run:
-          name: Authenticate with registry
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-      - run:
-          name: Publish Package
-          command: npm publish
+            - save_cache:
+                  key: v4-install-cache-{{ checksum "package-lock.json" }}
+                  paths:
+                      - ~/.npm
 
 workflows:
-  version: 2
-  install, test and lint:
-    jobs:
-      - install:
-          filters:
-            tags:
-              only: /^v.*/
-
-      - test:
-          context: Testing DB
-          filters:
-            tags:
-              only: /^v.*/
-          requires:
-            - install
-
-      - lint:
-          filters:
-            tags:
-              only: /^v.*/
-          requires:
-            - install
-
-      # - publish:
-      #     context: Deployment Keys
-      #     requires:
-      #       - test
-      #       - lint
-      #     filters:
-      #       tags:
-      #         only: /^v.*/
-      #       branches:
-      #         ignore: /.*/
+    test and publish:
+        jobs:
+            - test:
+                  context: Testing DB
+                  filters:
+                      tags:
+                          only: /^v.*/

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ const ORM = {
                 ORM.db.Op = Sequelize.Op;
                 ORM.db.Sequelize = Sequelize;
                 ORM.token_salt = config.secure_auth_salt || '';
+                ORM.chartIdSalt = config.orm.chartIdSalt;
                 ORM.plugins = configuredPlugins;
                 ORM.registerPlugins = createRegisterPlugins(ORM, configuredPlugins);
             } catch (err) {

--- a/models/Chart.js
+++ b/models/Chart.js
@@ -1,10 +1,25 @@
+const crypto = require('crypto');
 const SQ = require('sequelize');
-const { db } = require('../index');
+const { db, chartIdSalt } = require('../index');
 
 const Chart = db.define(
     'chart',
     {
         id: { type: SQ.STRING(5), primaryKey: true },
+        publicId: {
+            type: SQ.VIRTUAL,
+            get() {
+                if (chartIdSalt) {
+                    const hash = crypto.createHash('md5');
+                    hash.update(`${this.id}--${this.createdAt.toISOString()}--${chartIdSalt}`);
+                    return hash.digest('hex');
+                }
+                return this.id;
+            },
+            set() {
+                throw new Error('"publicId" is a virtual value and cannot be changed');
+            }
+        },
         type: SQ.STRING,
         title: SQ.STRING,
         theme: SQ.STRING,

--- a/package-lock.json
+++ b/package-lock.json
@@ -400,6 +400,21 @@
         }
       }
     },
+    "@datawrapper/shared": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@datawrapper/shared/-/shared-0.23.0.tgz",
+      "integrity": "sha512-6FQIv37+6mwMEC6cvVXZuYa3KRFqs+xKZpORrg6TpijRPzK4OjiHE3uV8551jxNcqzfF2zFI8QeR+NMSPaUchQ==",
+      "dev": true,
+      "requires": {
+        "chroma-js": "^2.0.3",
+        "d3-array": "^1.2.4",
+        "lodash-es": "^4.17.15",
+        "sinon": "^7.3.2",
+        "svelte": "^2.16.1",
+        "svelte-extras": "^2.0.2",
+        "underscore": "^1.9.1"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -441,6 +456,42 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -479,9 +530,9 @@
       "integrity": "sha1-T6duZZi33j8Mtuw6usxPWeWzos4="
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -626,6 +677,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-includes": {
@@ -1079,6 +1136,15 @@
         "readdirp": "~3.2.0"
       }
     },
+    "chroma-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.1.0.tgz",
+      "integrity": "sha512-uiRdh4ZZy+UTPSrAdp8hqEdVb1EllLtTHOt5TMaOjJUvi+O54/83Fc5K2ld1P+TJX+dw5B+8/sCgzI6eaur/lg==",
+      "dev": true,
+      "requires": {
+        "cross-env": "^6.0.3"
+      }
+    },
     "chunkd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/chunkd/-/chunkd-1.0.0.tgz",
@@ -1391,6 +1457,58 @@
         }
       }
     },
+    "cross-env": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+      "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1418,6 +1536,12 @@
       "requires": {
         "array-find-index": "^1.0.1"
       }
+    },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "dev": true
     },
     "date-fns": {
       "version": "1.30.1",
@@ -1609,6 +1733,12 @@
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
       "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1635,6 +1765,12 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
     },
     "dottie": {
       "version": "2.0.2",
@@ -3371,6 +3507,12 @@
         "object.assign": "^4.1.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -3863,6 +4005,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash-es": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
+      "dev": true
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -3954,6 +4102,12 @@
           }
         }
       }
+    },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+      "dev": true
     },
     "long": {
       "version": "4.0.0",
@@ -4258,6 +4412,30 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^5.0.1",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+          "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -4596,6 +4774,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -5246,6 +5441,32 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -5538,6 +5759,18 @@
         }
       }
     },
+    "svelte": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
+      "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg==",
+      "dev": true
+    },
+    "svelte-extras": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/svelte-extras/-/svelte-extras-2.0.2.tgz",
+      "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw==",
+      "dev": true
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -5725,6 +5958,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "scripts": {
         "format": "prettier 'models/**/*.js' --write",
         "lint": "prettier --check 'models/**/*.{js,html}' && healthier 'models/**/*.{js,html}'",
-        "test": "ava --verbose"
+        "test": "DW_CONFIG_PATH=tests/config._test.js ava --verbose"
     },
     "repository": {
         "type": "git",
@@ -30,8 +30,10 @@
         "underscore": "1.9.1"
     },
     "devDependencies": {
+        "@datawrapper/shared": "0.23.0",
         "ava": "~2.4.0",
         "babel-eslint": "~10.0.3",
+        "dotenv": "8.2.0",
         "healthier": "~3.2.0",
         "husky": "~1.3.1",
         "lint-staged": "~9.4.2",

--- a/tests/chart/chart-1.test.js
+++ b/tests/chart/chart-1.test.js
@@ -16,4 +16,15 @@ test('get metadata properties', t => {
     t.is(t.context.metadata.publish['embed-width'], 600);
 });
 
+test('chart has publicId', t => {
+    t.log(t.context.publicId);
+    t.truthy(t.context.publicId);
+});
+
+test('cannot set publicId', t => {
+    t.throws(() => {
+        t.context.publicId = 'foo';
+    });
+});
+
 test.after(t => close);

--- a/tests/config._test.js
+++ b/tests/config._test.js
@@ -1,0 +1,17 @@
+require('dotenv').config({
+    path: require('path').resolve('../../utils/docker/.datawrapper_env')
+});
+
+module.exports = {
+    orm: {
+        chartIdSalt: 'TEST_SALT',
+        db: {
+            dialect: 'mysql',
+            host: 'localhost',
+            port: process.env.DW_DATABASE_HOST_PORT,
+            user: process.env.DW_DATABASE_USER,
+            password: process.env.DW_DATABASE_PASS,
+            database: process.env.DW_DATABASE_NAME
+        }
+    }
+};

--- a/tests/config.ci.js
+++ b/tests/config.ci.js
@@ -8,6 +8,7 @@ module.exports = {
         lul: {}
     },
     orm: {
+        chartIdSalt: 'TEST_SALT',
         db: {
             dialect: 'mysql',
             host: process.env.DB_HOST,

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,5 +1,7 @@
 const ORM = require('../index');
-const config = require('./config');
+const { requireConfig } = require('@datawrapper/shared/node/findConfig');
+
+const config = requireConfig();
 
 const test = {
     init() {


### PR DESCRIPTION
Implements `publicId` functionality with Sequelize virtual fields.
> Virtual fields are fields that Sequelize populates under the hood, but in reality they don't even exist in the database.
> - https://sequelize.org/master/manual/getters-setters-virtuals.html#virtual-fields

This provides `chart.publicId` on any chart instance. If a `config.orm.chartIdSalt` is configured, the public ID is a MD5 hash based on chart ID, creation date and the salt.

Related schema PR: https://github.com/datawrapper/schemas/pull/11