### PR TITLE
fix: check for all values before computing public id hash

### DIFF
--- a/models/Chart.js
+++ b/models/Chart.js
@@ -9,7 +9,7 @@ const Chart = db.define(
         publicId: {
             type: SQ.VIRTUAL,
             get() {
-                if (chartIdSalt) {
+                if (this.id && this.createdAt && chartIdSalt) {
                     const hash = crypto.createHash('md5');
                     hash.update(`${this.id}--${this.createdAt.toISOString()}--${chartIdSalt}`);
                     return hash.digest('hex');


### PR DESCRIPTION
After using `chart.publicId` I encountered a weird crash of my code, with the following error: 

> `TypeError: Cannot read property 'toISOString' of undefined`

This  relates to the `this.createdAt.toISOString()` call in the getter of `publicId`. After some investigation it was caused by a `Chart.update` call. It looks like Sequelize tries to compute the public id when updating data and creates a `Chart` instance with `chart.id = null` and `chart.createdAt = undefined`. This caused the crash. By guarding against these missing properties, the problem is gone.

Again something learned from Sequelize.