### PR TITLE
add user.getActiveProduct + tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# Lines starting with '#' are comments.
-# Each line is a file pattern followed by one or more owners.
-
-*     @gka @davidkokkelink @ilokhov @sto3psl

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datawrapper/orm",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/orm",
-    "version": "3.11.0",
+    "version": "3.12.0",
     "description": "A database abstraction layer for Datawrapper",
     "homepage": "https://github.com/datawrapper/orm#readme",
     "license": "MIT",

--- a/tests/team.test.js
+++ b/tests/team.test.js
@@ -11,10 +11,10 @@ test.before(async t => {
     t.context = await Team.findByPk('team-1');
 });
 
-test('team.getUsers returns two users', async t => {
+test('team.getUsers returns three users', async t => {
     t.is(typeof t.context.getUsers, 'function', 'team.getUsers() is undefined');
     const result = await t.context.getUsers();
-    t.is(result.length, 2);
+    t.is(result.length, 3);
 });
 
 test.after(t => close);

--- a/tests/user/user-3.test.js
+++ b/tests/user/user-3.test.js
@@ -17,13 +17,13 @@ test.before(async t => {
         attributes: {
             include: [[db.fn('COUNT', db.col('charts.id')), 'chart_count']]
         },
-        order: [[db.fn('COUNT', db.literal('charts.id')), 'DESC']]
+        order: [[db.fn('COUNT', db.literal('charts.id')), 'DESC'], ['id', 'ASC']]
     });
 });
 
-test('found three users, sorted by chart count', t => {
-    // 3 users in total
-    t.is(t.context.length, 3);
+test('found five users, sorted by chart count', t => {
+    // 4 users in total
+    t.is(t.context.length, 5);
     // first has two charts
     t.is(t.context[0].get('email'), 'ci3@datawrapper.de');
     t.is(t.context[0].get('chart_count'), 2);

--- a/tests/user/user-products.test.js
+++ b/tests/user/user-products.test.js
@@ -1,0 +1,49 @@
+const test = require('ava');
+const { close, init } = require('../index');
+
+test.before(async t => {
+    await init();
+    const { User } = require('../../models');
+    t.context.models = { User };
+});
+
+test('user 1 has no products', async t => {
+    const { User } = t.context.models;
+    const user = await User.findByPk(1);
+    const activeProduct = await user.getActiveProduct();
+    t.falsy(activeProduct);
+});
+
+test('user 2 has product 1 (through team)', async t => {
+    const { User } = t.context.models;
+    const user = await User.findByPk(2);
+    const activeProduct = await user.getActiveProduct();
+    t.truthy(activeProduct);
+    t.is(activeProduct.id, 1);
+});
+
+test('user 3 has product 2 (same team, but user product has higher prio)', async t => {
+    const { User } = t.context.models;
+    const user = await User.findByPk(3);
+    const activeProduct = await user.getActiveProduct();
+    t.truthy(activeProduct);
+    t.is(activeProduct.id, 2);
+});
+
+test('user 4 has product 1 through user-product', async t => {
+    const { User } = t.context.models;
+    const user = await User.findByPk(4);
+    const activeProduct = await user.getActiveProduct();
+    t.truthy(activeProduct);
+    t.is(activeProduct.id, 1);
+});
+
+test('user 5 has product 3 (two teams, but one has higher prio)', async t => {
+    const { User } = t.context.models;
+    const user = await User.findByPk(5);
+    const activeProduct = await user.getActiveProduct();
+    t.truthy(activeProduct);
+    t.is(activeProduct.id, 3);
+});
+
+test.after(t => close);


### PR DESCRIPTION
This PR adds the functionality to return the "active" product of a user. Like the [previous PHP implementation](https://github.com/datawrapper/datawrapper/blob/node-publishing/lib/core/build/classes/datawrapper/User.php#L324-L365] this checks both products through `UserProduct` and products through `TeamProduct`.