### PR TITLE
prevent edits of deleted charts

### DIFF
--- a/models/Chart.js
+++ b/models/Chart.js
@@ -55,6 +55,7 @@ Chart.belongsTo(Chart, {
 });
 
 Chart.prototype.isEditableBy = async function(user, session) {
+    if (this.deleted) return false;
     if (user) {
         return user.mayEditChart(this);
     } else if (session) {


### PR DESCRIPTION
this PR adds a check for `chart.deleted` to `isEditableBy`. This will also affect `isPublishableBy`.