### PR TITLE
Check guest session correctly

### DIFF
--- a/models/Chart.js
+++ b/models/Chart.js
@@ -56,10 +56,11 @@ Chart.belongsTo(Chart, {
 
 Chart.prototype.isEditableBy = async function(user, session) {
     if (this.deleted) return false;
-    if (user) {
+
+    if (user && user.role !== 'guest') {
         return user.mayEditChart(this);
     } else if (session) {
-        return this.guest_session && this.guest_session === session.id;
+        return this.guest_session && this.guest_session === session;
     }
     return false;
 };


### PR DESCRIPTION
There were two errors in the `Chart.isEditableBy` check that currently result in it always being false for guests:
- guests have user objects, too, so we have to check `user.role === 'guest'`
- the sessionId is passed in directly, and not as an object that can be accessed like `session.id` 