### PR TITLE
simplify user plugin check

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -127,16 +127,26 @@ User.prototype.getAllProducts = async function() {
  * @returns true|false
  */
 User.prototype.mayUsePlugin = async function(pluginId) {
+    // check if the plugin is available for everyone
     const Plugin = require('./Plugin');
-    const plugin = await Plugin.findByPk(pluginId);
-    if (!plugin.is_private) return true;
-    // look through all the products of this user
-    const products = await this.getAllProducts();
-    for (const product of products) {
-        const allow = await product.hasPlugin(pluginId);
-        if (allow) return true;
+    const plugin = await Plugin.fineOne({
+        where: {
+            id: pluginId,
+            enabled: true
+        }
+    });
+    if (!plugin) {
+        // the plugin doesn't exist or is disabled
+        return false;
     }
-    return false;
+    if (!plugin.is_private) {
+        // the plugin exists and is not set to private
+        return true;
+    }
+    // finally if the user has access to the plugin
+    const userPlugins = await this.getUserPluginCache();
+    const plugins = userPlugins && userPlugins.plugins ? userPlugins.plugins.split(',') : [];
+    return plugins.includes(pluginId);
 };
 
 /*

--- a/models/User.js
+++ b/models/User.js
@@ -129,7 +129,7 @@ User.prototype.getAllProducts = async function() {
 User.prototype.mayUsePlugin = async function(pluginId) {
     // check if the plugin is available for everyone
     const Plugin = require('./Plugin');
-    const plugin = await Plugin.fineOne({
+    const plugin = await Plugin.findOne({
         where: {
             id: pluginId,
             enabled: true

--- a/tests/user/user-plugins.test.js
+++ b/tests/user/user-plugins.test.js
@@ -13,8 +13,17 @@ test('user 1 has access to plugin', async t => {
     t.true(plugins.includes('export-pdf'));
 });
 
-test('user may use plugin', async t => {
+test('user.mayUsePlugin', async t => {
+    // export-pdf is public
     t.true(await t.context.mayUsePlugin('export-pdf'));
+    // plugin foo does not exist
+    t.false(await t.context.mayUsePlugin('foo'));
+    // disabled-plugin is public but not enabled
+    t.false(await t.context.mayUsePlugin('disabled-plugin'));
+    // private-plugin is private but user has access through userPluginCache
+    t.true(await t.context.mayUsePlugin('private-plugin'));
+    // private-plugin-2 is private and user has no access through userPluginCache
+    t.false(await t.context.mayUsePlugin('private-plugin-2'));
 });
 
 test.after(t => close);

--- a/tests/user/user-plugins.test.js
+++ b/tests/user/user-plugins.test.js
@@ -13,4 +13,8 @@ test('user 1 has access to plugin', async t => {
     t.true(plugins.includes('export-pdf'));
 });
 
+test('user may use plugin', async t => {
+    t.true(await t.context.mayUsePlugin('export-pdf'));
+});
+
 test.after(t => close);

--- a/tests/user/user-plugins.test.js
+++ b/tests/user/user-plugins.test.js
@@ -13,15 +13,18 @@ test('user 1 has access to plugin', async t => {
     t.true(plugins.includes('export-pdf'));
 });
 
-test('user.mayUsePlugin', async t => {
+test('user may use plugin', async t => {
     // export-pdf is public
     t.true(await t.context.mayUsePlugin('export-pdf'));
+    // private-plugin is private but user has access through userPluginCache
+    t.true(await t.context.mayUsePlugin('private-plugin'));
+});
+
+test('user not use plugin', async t => {
     // plugin foo does not exist
     t.false(await t.context.mayUsePlugin('foo'));
     // disabled-plugin is public but not enabled
     t.false(await t.context.mayUsePlugin('disabled-plugin'));
-    // private-plugin is private but user has access through userPluginCache
-    t.true(await t.context.mayUsePlugin('private-plugin'));
     // private-plugin-2 is private and user has no access through userPluginCache
     t.false(await t.context.mayUsePlugin('private-plugin-2'));
 });


### PR DESCRIPTION
the idea is to replace [checks like these](https://github.com/datawrapper/api/blob/publish/src/routes/charts.js#L803-L817) in our API with a simple `await User.mayUsePlugin('export-pdf')`.