### PR TITLE
Fix product check for two products with equal priority

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -202,12 +202,13 @@ User.prototype.getActiveProduct = async function() {
     // sort each teams highest priority products by priority, again
     const teamProduct = teamProducts.sort((a, b) => b.priority - a.priority)[0];
 
-    if (userProduct && (!teamProduct || userProduct.priority > teamProduct.priority)) {
+    if (userProduct && (!teamProduct || userProduct.priority >= teamProduct.priority)) {
         return userProduct;
     }
     if (teamProduct && (!userProduct || teamProduct.priority > userProduct.priority)) {
         return teamProduct;
     }
+
     return null;
 };
 


### PR DESCRIPTION
This PR fixes a bug in `User.getActiveProduct`: Before, when a user had both a `userProduct` and `teamProduct` with the same priority, this method would return `null` as no product has a higher priority. This PR fixes it (by defaulting to the `userProduct`)