### PR TITLE
Add User.getActiveTeam helper function

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -219,4 +219,30 @@ User.prototype.getActiveProduct = async function() {
     return null;
 };
 
+/*
+ * returns the currently active team, or null if it doesn't exist
+ */
+User.prototype.getActiveTeam = async function(session) {
+    const { getUserData } = require('../utils/userData');
+
+    const teams = await this.getTeams();
+    if (teams.length < 1) return null;
+
+    let activeTeam = await getUserData(this, 'active_team');
+
+    if (!activeTeam && session) {
+        activeTeam = session.data['dw-user-organization'];
+    }
+
+    if (activeTeam === '%none%') return null;
+
+    for (const team of teams) {
+        if (team.id === activeTeam) {
+            return team;
+        }
+    }
+
+    return teams[0];
+};
+
 module.exports = User;


### PR DESCRIPTION
This PR adds `getActiveTeam` to the `User` model, which returns the currently selected team in Datawrapper. Implementation is 1:1 equivalent too the existing [PHP implementation](https://github.com/datawrapper/datawrapper/blob/master/lib/core/build/classes/datawrapper/User.php#L112-L126), just renamed from `getCurrentOrganization` to `getActiveTeam`. 

This is mostly used to determine where to place newly created charts.