### PR TITLE
Move Chart.publicId to Chart.getPublicId method

### DIFF
--- a/models/Chart.js
+++ b/models/Chart.js
@@ -48,7 +48,10 @@ Chart.prototype.getPublicId = async function() {
         useHash = true;
     } else if (this.organization_id) {
         const team = await Team.findByPk(this.organization_id);
-        useHash = team.settings && team.settings.hashPublishing;
+        useHash =
+            team.settings &&
+            team.settings.publishTarget &&
+            team.settings.publishTarget.hash_publishing;
     }
 
     if (!useHash) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4001,9 +4001,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash-es": {
       "version": "4.17.15",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     },
     "dependencies": {
         "assign-deep": "^1.0.1",
+        "lodash": "^4.17.20",
         "merge-deep": "^3.0.2",
         "mysql2": "1.7.0",
         "nanoid": "2.1.6",

--- a/tests/chart/chart-1.test.js
+++ b/tests/chart/chart-1.test.js
@@ -16,15 +16,4 @@ test('get metadata properties', t => {
     t.is(t.context.metadata.publish['embed-width'], 600);
 });
 
-test('chart has publicId', t => {
-    t.log(t.context.publicId);
-    t.truthy(t.context.publicId);
-});
-
-test('cannot set publicId', t => {
-    t.throws(() => {
-        t.context.publicId = 'foo';
-    });
-});
-
 test.after(t => close);

--- a/tests/chart/chart-1.test.js
+++ b/tests/chart/chart-1.test.js
@@ -16,4 +16,8 @@ test('get metadata properties', t => {
     t.is(t.context.metadata.publish['embed-width'], 600);
 });
 
+test('chart has publicId', t => {
+    t.is(typeof t.context.getPublicId, 'function');
+});
+
 test.after(t => close);


### PR DESCRIPTION
In order to support hash-publishing for teams, we need to determine whether to use the hash-based ID based on the team settings. To implement this, I replaced the 'virtual field' implementation with a model prototype method `getPublicId`. While it could have been implemented as a virtual field, the need for the team setting lookup caused too many needless database queries whenever a chart was loaded using the ORM, so I added the method so it's only loaded when needed.

The new team setting is part of the 'self-hosting' feature (though it could be enabled when using our CDN, too) and stored in `settings.publishTarget.hash_publishing`. The mixture of camel- and snake-case is annoying but consistent with the other options.