### PR TITLE
Check User.role for activation status

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -76,7 +76,7 @@ User.prototype.isAdmin = function() {
  * check if the user has activated their account
  */
 User.prototype.isActivated = function() {
-    return !this.activate_token && this.role !== 'pending' && this.role !== 'guest';
+    return this.role !== 'pending' && this.role !== 'guest';
 };
 
 /*


### PR DESCRIPTION
We shouldn't check `user.activate_token` for this, as it's deprecated but also currently (ab-)used for verification when a user changes their email