### PR TITLE
Add Chart.getThumbnailHash

### DIFF
--- a/models/Chart.js
+++ b/models/Chart.js
@@ -76,4 +76,13 @@ Chart.prototype.isPublishableBy = async function(user) {
     return false;
 };
 
+Chart.prototype.getThumbnailHash = function() {
+    if (this.createdAt) {
+        return crypto
+            .createHash('md5')
+            .update(`${this.id}--${this.createdAt.getTime() / 1000}`)
+            .digest('hex');
+    }
+};
+
 module.exports = Chart;


### PR DESCRIPTION
API & frontend will both need to access this at times so it makes sense to move it to the ORM