### PR TITLE
Fix user plugin check

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -160,12 +160,7 @@ User.prototype.mayUsePlugin = async function(pluginId) {
     }
 
     const userPlugins = await this.getPlugins();
-
-    if (userPlugins.filter(plugin => plugin.id === pluginId).length > 0) {
-        return true;
-    }
-
-    return false;
+    return userPlugins.filter(plugin => plugin.id === pluginId).length > 0;
 };
 
 /*

--- a/models/User.js
+++ b/models/User.js
@@ -151,9 +151,21 @@ User.prototype.mayUsePlugin = async function(pluginId) {
         return true;
     }
     // finally if the user has access to the plugin
-    const userPlugins = await this.getUserPluginCache();
-    const plugins = userPlugins && userPlugins.plugins ? userPlugins.plugins.split(',') : [];
-    return plugins.includes(pluginId);
+    const cachedUserPlugins = await this.getUserPluginCache();
+    const cachedPlugins =
+        cachedUserPlugins && cachedUserPlugins.plugins ? cachedUserPlugins.plugins.split(',') : [];
+
+    if (cachedPlugins.includes(pluginId)) {
+        return true;
+    }
+
+    const userPlugins = await this.getPlugins();
+
+    if (userPlugins.filter(plugin => plugin.id === pluginId).length > 0) {
+        return true;
+    }
+
+    return false;
 };
 
 /*

--- a/models/User.js
+++ b/models/User.js
@@ -150,13 +150,13 @@ User.prototype.mayUsePlugin = async function(pluginId) {
         // the plugin exists and is not set to private
         return true;
     }
+
     // finally if the user has access to the plugin
     const cachedUserPlugins = await this.getUserPluginCache();
-    const cachedPlugins =
-        cachedUserPlugins && cachedUserPlugins.plugins ? cachedUserPlugins.plugins.split(',') : [];
 
-    if (cachedPlugins.includes(pluginId)) {
-        return true;
+    if (cachedUserPlugins) {
+        const cachedPlugins = cachedUserPlugins.plugins ? cachedUserPlugins.plugins.split(',') : [];
+        return cachedPlugins.includes(pluginId);
     }
 
     const userPlugins = await this.getPlugins();


### PR DESCRIPTION
This PR fixes `User.mayUsePlugin`. Before, it only checked the `userPluginCache` to determine whether a plugin is usable. However, there are scenarios when that cache may be empty, in which we case we need to lookup the actual relation.