### PR TITLE
Get correct active team

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -251,7 +251,7 @@ User.prototype.getActiveTeam = async function(session) {
     const teams = await this.getTeams();
     if (teams.length < 1) return null;
 
-    let activeTeam = await getUserData(this, 'active_team');
+    let activeTeam = await getUserData(this.id, 'active_team');
 
     if (!activeTeam && session) {
         activeTeam = session.data['dw-user-organization'];


### PR DESCRIPTION
`getUserData` expects parameter 1 [to be the user ID](https://github.com/datawrapper/orm/blob/master/utils/userData.js#L11), not a user object