### PR TITLE
Allow using PublicChart as Chart

### DIFF
--- a/models/Chart.js
+++ b/models/Chart.js
@@ -43,23 +43,22 @@ Chart.belongsTo(Chart, {
     foreignKey: 'forked_from'
 });
 
-Chart.prototype.setDataValuesFromPublicChart = async function() {
-    const { ChartPublic } = require('@datawrapper/orm/models');
+Chart.prototype.setAttributesFromPublicChart = async function() {
+    const { ChartPublic } = require('../models');
     const publicChart = await ChartPublic.findOne({ where: { id: this.id } });
     if (!publicChart) {
         return false;
     }
-    Object.assign(
-        this.dataValues,
-        pick(publicChart, [
-            'type',
-            'title',
-            'metadata',
-            'external_data',
-            'author_id',
-            'organization_id'
-        ])
-    );
+    for (const attr of [
+        'type',
+        'title',
+        'metadata',
+        'external_data',
+        'author_id',
+        'organization_id'
+    ]) {
+        this.set(attr, publicChart[attr]);
+    }
     return true;
 };
 

--- a/models/Chart.js
+++ b/models/Chart.js
@@ -3,6 +3,7 @@ const SQ = require('sequelize');
 const { db, chartIdSalt, hashPublishing } = require('../index');
 const Team = require('../models/Team');
 const get = require('lodash/get');
+const pick = require('lodash/pick');
 
 const Chart = db.define(
     'chart',
@@ -41,6 +42,26 @@ const Chart = db.define(
 Chart.belongsTo(Chart, {
     foreignKey: 'forked_from'
 });
+
+Chart.prototype.setDataValuesFromPublicChart = async function() {
+    const { ChartPublic } = require('@datawrapper/orm/models');
+    const publicChart = await ChartPublic.findOne({ where: { id: this.id } });
+    if (!publicChart) {
+        return false;
+    }
+    Object.assign(
+        this.dataValues,
+        pick(publicChart, [
+            'type',
+            'title',
+            'metadata',
+            'external_data',
+            'author_id',
+            'organization_id'
+        ])
+    );
+    return true;
+};
 
 Chart.prototype.getPublicId = async function() {
     if (this.id && chartIdSalt && this.createdAt) {

--- a/models/Chart.js
+++ b/models/Chart.js
@@ -1,65 +1,18 @@
-const crypto = require('crypto');
 const SQ = require('sequelize');
-const { db, chartIdSalt, hashPublishing } = require('../index');
-const Team = require('../models/Team');
+const Team = require('./Team');
+const chartAttributes = require('./chartAttributes');
+const crypto = require('crypto');
 const get = require('lodash/get');
+const { db, chartIdSalt, hashPublishing } = require('../index');
 
-const Chart = db.define(
-    'chart',
-    {
-        id: { type: SQ.STRING(5), primaryKey: true },
-        type: SQ.STRING,
-        title: SQ.STRING,
-        theme: SQ.STRING,
-
-        guest_session: SQ.STRING,
-
-        last_edit_step: SQ.INTEGER,
-
-        published_at: SQ.DATE,
-        public_url: SQ.STRING,
-        public_version: SQ.INTEGER,
-
-        deleted: SQ.BOOLEAN,
-        deleted_at: SQ.DATE,
-
-        forkable: SQ.BOOLEAN,
-        is_fork: SQ.BOOLEAN,
-
-        metadata: SQ.JSON,
-        language: SQ.STRING(5),
-        external_data: SQ.STRING(),
-
-        utf8: SQ.BOOLEAN
-    },
-    {
-        updatedAt: 'last_modified_at',
-        tableName: 'chart'
-    }
-);
+const Chart = db.define('chart', chartAttributes, {
+    updatedAt: 'last_modified_at',
+    tableName: 'chart'
+});
 
 Chart.belongsTo(Chart, {
     foreignKey: 'forked_from'
 });
-
-Chart.prototype.setAttributesFromPublicChart = async function() {
-    const { ChartPublic } = require('../models');
-    const publicChart = await ChartPublic.findOne({ where: { id: this.id } });
-    if (!publicChart) {
-        return false;
-    }
-    for (const attr of [
-        'type',
-        'title',
-        'metadata',
-        'external_data',
-        'author_id',
-        'organization_id'
-    ]) {
-        this.set(attr, publicChart[attr]);
-    }
-    return true;
-};
 
 Chart.prototype.getPublicId = async function() {
     if (this.id && chartIdSalt && this.createdAt) {

--- a/models/Chart.js
+++ b/models/Chart.js
@@ -3,7 +3,6 @@ const SQ = require('sequelize');
 const { db, chartIdSalt, hashPublishing } = require('../index');
 const Team = require('../models/Team');
 const get = require('lodash/get');
-const pick = require('lodash/pick');
 
 const Chart = db.define(
     'chart',

--- a/models/ReadonlyChart.js
+++ b/models/ReadonlyChart.js
@@ -25,8 +25,7 @@ ReadonlyChart.fromChart = function(chart) {
     return ReadonlyChart.build(chart.get());
 };
 
-ReadonlyChart.fromPublicChart = async function(publicChart) {
-    const chart = await publicChart.getChart();
+ReadonlyChart.fromPublicChart = async function(chart, publicChart) {
     return ReadonlyChart.build({
         ...chart.get(),
         ...pick(publicChart.get(), [

--- a/models/ReadonlyChart.js
+++ b/models/ReadonlyChart.js
@@ -17,12 +17,8 @@ ReadonlyChart.init(chartAttributes, {
     }
 });
 
-ReadonlyChart.belongsTo(Chart, {
-    foreignKey: 'forked_from'
-});
-
+ReadonlyChart.belongsTo(Chart, { foreignKey: 'forked_from' });
 ReadonlyChart.belongsTo(Team, { foreignKey: 'organization_id' });
-
 ReadonlyChart.belongsTo(User, { foreignKey: 'author_id' });
 
 ReadonlyChart.fromChart = function(chart) {

--- a/models/ReadonlyChart.js
+++ b/models/ReadonlyChart.js
@@ -1,0 +1,47 @@
+const Chart = require('./Chart');
+const Team = require('./Team');
+const User = require('./User');
+const SQ = require('sequelize');
+const chartAttributes = require('./chartAttributes');
+const pick = require('lodash/pick');
+const { db } = require('../index');
+
+class ReadonlyChart extends Chart {}
+
+ReadonlyChart.init(chartAttributes, {
+    sequelize: db,
+    validate: {
+        never() {
+            throw new Error('ReadonlyChart can never be saved to the database');
+        }
+    }
+});
+
+ReadonlyChart.belongsTo(Chart, {
+    foreignKey: 'forked_from'
+});
+
+ReadonlyChart.belongsTo(Team, { foreignKey: 'organization_id' });
+
+ReadonlyChart.belongsTo(User, { foreignKey: 'author_id' });
+
+ReadonlyChart.fromChart = function(chart) {
+    return ReadonlyChart.build(chart.get());
+};
+
+ReadonlyChart.fromPublicChart = async function(publicChart) {
+    const chart = await publicChart.getChart();
+    return ReadonlyChart.build({
+        ...chart.get(),
+        ...pick(publicChart.get(), [
+            'type',
+            'title',
+            'metadata',
+            'external_data',
+            'author_id',
+            'organization_id'
+        ])
+    });
+};
+
+module.exports = ReadonlyChart;

--- a/models/chartAttributes.js
+++ b/models/chartAttributes.js
@@ -1,0 +1,28 @@
+const SQ = require('sequelize');
+
+module.exports = {
+    id: { type: SQ.STRING(5), primaryKey: true },
+    type: SQ.STRING,
+    title: SQ.STRING,
+    theme: SQ.STRING,
+
+    guest_session: SQ.STRING,
+
+    last_edit_step: SQ.INTEGER,
+
+    published_at: SQ.DATE,
+    public_url: SQ.STRING,
+    public_version: SQ.INTEGER,
+
+    deleted: SQ.BOOLEAN,
+    deleted_at: SQ.DATE,
+
+    forkable: SQ.BOOLEAN,
+    is_fork: SQ.BOOLEAN,
+
+    metadata: SQ.JSON,
+    language: SQ.STRING(5),
+    external_data: SQ.STRING(),
+
+    utf8: SQ.BOOLEAN
+};

--- a/models/index.js
+++ b/models/index.js
@@ -12,6 +12,7 @@ const models = {};
     'PluginData',
     'Product',
     'ProductPlugin',
+    'ReadonlyChart',
     'Session',
     'Stats',
     'Team',

--- a/models/index.js
+++ b/models/index.js
@@ -12,7 +12,6 @@ const models = {};
     'PluginData',
     'Product',
     'ProductPlugin',
-    'ReadonlyChart',
     'Session',
     'Stats',
     'Team',

--- a/tests/chartPublic.test.js
+++ b/tests/chartPublic.test.js
@@ -64,7 +64,7 @@ test('associated chart exists', async t => {
 });
 
 test('ReadonlyChart.fromChart builds a new chart instance with values from passed chart', async t => {
-    const { ReadonlyChart } = require('../models');
+    const ReadonlyChart = require('../models/ReadonlyChart');
     const { chart, chartTeam, chartUser } = t.context;
     const readonlyChart = await ReadonlyChart.fromChart(chart);
 
@@ -93,7 +93,7 @@ test('ReadonlyChart.fromChart builds a new chart instance with values from passe
 });
 
 test('ReadonlyChart.fromPublicChart builds a new chart instance with values from passed public chart', async t => {
-    const { ReadonlyChart } = require('../models');
+    const ReadonlyChart = require('../models/ReadonlyChart');
     const { chart, publicChart, publicChartTeam, publicChartUser } = t.context;
     const readonlyChart = await ReadonlyChart.fromPublicChart(publicChart);
 
@@ -125,7 +125,7 @@ test('ReadonlyChart.fromPublicChart builds a new chart instance with values from
 });
 
 test('ReadonlyChart cannot be saved', async t => {
-    const { ReadonlyChart } = require('../models');
+    const ReadonlyChart = require('../models/ReadonlyChart');
     const { chart } = t.context;
     const readonlyChart = await ReadonlyChart.fromChart(chart);
 

--- a/tests/chartPublic.test.js
+++ b/tests/chartPublic.test.js
@@ -1,18 +1,37 @@
 const test = require('ava');
-const { createChart, destroy } = require('./helpers/fixtures');
+const { createChart, createTeam, createUser, destroy } = require('./helpers/fixtures');
 const { init } = require('./helpers/orm');
 
 test.before(async t => {
     t.context.orm = await init();
 
     const { ChartPublic } = require('../models');
+
+    t.context.chartTeam = await createTeam();
+    t.context.chartUser = await createUser({ teams: [t.context.chartTeam] });
     t.context.chart = await createChart({
-        title: 'Test chart'
+        type: 'd3-bars',
+        title: 'Test chart',
+        metadata: {
+            foo: 'chart metadata'
+        },
+        external_data: 'chart external data',
+        author_id: t.context.chartUser.id,
+        organization_id: t.context.chartTeam.id
     });
 
+    t.context.publicChartTeam = await createTeam();
+    t.context.publicChartUser = await createUser({ teams: [t.context.publicChartTeam] });
     t.context.publicChart = await ChartPublic.create({
         id: t.context.chart.id,
-        title: 'Test chart public'
+        type: 'd3-lines',
+        title: 'Test chart public',
+        metadata: {
+            bar: 'public chart metadata'
+        },
+        external_data: 'public chart external data',
+        author_id: t.context.publicChartUser.id,
+        organization_id: t.context.publicChartTeam.id
     });
 });
 
@@ -28,4 +47,18 @@ test('associated chart exists', async t => {
     t.is(publicChart.id, chart.id);
     t.is(publicChart.title, 'Test chart public');
     t.is(chart.title, 'Test chart');
+});
+
+test('chart.setAttributesFromPublicChart copies attributes from associated public chart', async t => {
+    const { chart, publicChart, publicChartTeam, publicChartUser } = t.context;
+    const newChart = await publicChart.getChart();
+    await newChart.setAttributesFromPublicChart();
+
+    t.is(newChart.id, chart.id);
+    t.is(newChart.type, publicChart.type);
+    t.is(newChart.title, publicChart.title);
+    t.deepEqual(newChart.metadata, publicChart.metadata);
+    t.is(newChart.external_data, publicChart.external_data);
+    t.is((await newChart.getUser()).id, publicChartUser.id);
+    t.is((await newChart.getTeam()).id, publicChartTeam.id);
 });

--- a/tests/chartPublic.test.js
+++ b/tests/chartPublic.test.js
@@ -95,7 +95,7 @@ test('ReadonlyChart.fromChart builds a new chart instance with values from passe
 test('ReadonlyChart.fromPublicChart builds a new chart instance with values from passed public chart', async t => {
     const ReadonlyChart = require('../models/ReadonlyChart');
     const { chart, publicChart, publicChartTeam, publicChartUser } = t.context;
-    const readonlyChart = await ReadonlyChart.fromPublicChart(publicChart);
+    const readonlyChart = await ReadonlyChart.fromPublicChart(chart, publicChart);
 
     t.true(readonlyChart instanceof ReadonlyChart);
     t.truthy(readonlyChart.createdAt);

--- a/tests/chartPublic.test.js
+++ b/tests/chartPublic.test.js
@@ -69,7 +69,9 @@ test('ReadonlyChart.fromChart builds a new chart instance with values from passe
     const readonlyChart = await ReadonlyChart.fromChart(chart);
 
     t.true(readonlyChart instanceof ReadonlyChart);
+    t.truthy(readonlyChart.createdAt);
     t.is(readonlyChart.id, chart.id);
+    t.is(await readonlyChart.getPublicId(), chart.id);
     t.is(readonlyChart.type, chart.type);
     t.is(readonlyChart.title, chart.title);
     t.is(readonlyChart.theme, chart.theme);
@@ -96,8 +98,10 @@ test('ReadonlyChart.fromPublicChart builds a new chart instance with values from
     const readonlyChart = await ReadonlyChart.fromPublicChart(publicChart);
 
     t.true(readonlyChart instanceof ReadonlyChart);
+    t.truthy(readonlyChart.createdAt);
     // Chart attributes
     t.is(readonlyChart.id, chart.id);
+    t.is(await readonlyChart.getPublicId(), chart.id);
     t.is(readonlyChart.theme, chart.theme);
     t.is(readonlyChart.guest_session, chart.guest_session);
     t.is(readonlyChart.last_edit_step, chart.last_edit_step);


### PR DESCRIPTION
#### Motivation

In many parts of the project, we want to use PublicChart as if it was Chart.

#### Changes

One solution to the problem would be to make Chart and PublicChart compatible (have them implement same methods). I believe this is (a) fragile and (b) can cause confusion by obscuring what model we're dealing with.

Therefore I propose a different solution: Copy the current state of PublicChart into a Chart and then work with the Chart only.

See https://github.com/datawrapper/api/pull/327 for usage.