### PR TITLE
ReadonlyChart: Copy included model from chart

### DIFF
--- a/models/ReadonlyChart.js
+++ b/models/ReadonlyChart.js
@@ -6,7 +6,33 @@ const chartAttributes = require('./chartAttributes');
 const pick = require('lodash/pick');
 const { db } = require('../index');
 
-class ReadonlyChart extends Chart {}
+class ReadonlyChart extends Chart {
+    get user() {
+        return this.dataValues.user;
+    }
+
+    static async fromChart(chart) {
+        const readonlyChart = ReadonlyChart.build({ id: chart.id });
+        readonlyChart.dataValues = { ...chart.dataValues };
+        return readonlyChart;
+    }
+
+    static async fromPublicChart(chart, publicChart) {
+        const readonlyChart = ReadonlyChart.build({ id: chart.id });
+        readonlyChart.dataValues = {
+            ...chart.dataValues,
+            ...pick(publicChart.dataValues, [
+                'type',
+                'title',
+                'metadata',
+                'external_data',
+                'author_id',
+                'organization_id'
+            ])
+        };
+        return readonlyChart;
+    }
+}
 
 ReadonlyChart.init(chartAttributes, {
     sequelize: db,
@@ -20,23 +46,5 @@ ReadonlyChart.init(chartAttributes, {
 ReadonlyChart.belongsTo(Chart, { foreignKey: 'forked_from' });
 ReadonlyChart.belongsTo(Team, { foreignKey: 'organization_id' });
 ReadonlyChart.belongsTo(User, { foreignKey: 'author_id' });
-
-ReadonlyChart.fromChart = function(chart) {
-    return ReadonlyChart.build(chart.get());
-};
-
-ReadonlyChart.fromPublicChart = async function(chart, publicChart) {
-    return ReadonlyChart.build({
-        ...chart.get(),
-        ...pick(publicChart.get(), [
-            'type',
-            'title',
-            'metadata',
-            'external_data',
-            'author_id',
-            'organization_id'
-        ])
-    });
-};
 
 module.exports = ReadonlyChart;

--- a/tests/chartPublic.test.js
+++ b/tests/chartPublic.test.js
@@ -124,6 +124,35 @@ test('ReadonlyChart.fromPublicChart builds a new chart instance with values from
     t.is((await readonlyChart.getTeam()).id, publicChartTeam.id);
 });
 
+test('ReadonlyChart.fromChart copies included model from passed chart', async t => {
+    const Chart = require('../models/Chart');
+    const ReadonlyChart = require('../models/ReadonlyChart');
+    const { chart, chartUser } = t.context;
+
+    const readonlyChart = await ReadonlyChart.fromChart(chart);
+    t.is(readonlyChart.user, undefined);
+
+    const chartWithUser = await Chart.findOne({ where: { id: chart.id }, include: 'user' });
+    const readonlyChartWithUser = await ReadonlyChart.fromChart(chartWithUser);
+    t.is(readonlyChartWithUser.user.id, chartUser.id);
+    t.is(readonlyChartWithUser.user.id, readonlyChartWithUser.dataValues.user.id);
+});
+
+test('ReadonlyChart.fromPublicChart copies included model from passed chart', async t => {
+    const Chart = require('../models/Chart');
+    const ChartPublic = require('../models/ChartPublic');
+    const ReadonlyChart = require('../models/ReadonlyChart');
+    const { chart, chartUser, publicChart, publicChartUser } = t.context;
+
+    const readonlyChart = await ReadonlyChart.fromPublicChart(chart, publicChart);
+    t.is(readonlyChart.user, undefined);
+
+    const chartWithUser = await Chart.findOne({ where: { id: chart.id }, include: 'user' });
+    const readonlyChartWithUser = await ReadonlyChart.fromPublicChart(chartWithUser, publicChart);
+    t.is(readonlyChartWithUser.user.id, chartUser.id);
+    t.is(readonlyChartWithUser.user.id, readonlyChartWithUser.dataValues.user.id);
+});
+
 test('ReadonlyChart cannot be saved', async t => {
     const ReadonlyChart = require('../models/ReadonlyChart');
     const { chart } = t.context;

--- a/tests/chartPublic.test.js
+++ b/tests/chartPublic.test.js
@@ -136,11 +136,11 @@ test('ReadonlyChart.fromChart copies included model from passed chart', async t 
     const readonlyChartWithUser = await ReadonlyChart.fromChart(chartWithUser);
     t.is(readonlyChartWithUser.user.id, chartUser.id);
     t.is(readonlyChartWithUser.user.id, readonlyChartWithUser.dataValues.user.id);
+    t.is(readonlyChartWithUser.user.id, readonlyChartWithUser.author_id);
 });
 
 test('ReadonlyChart.fromPublicChart copies included model from passed chart', async t => {
     const Chart = require('../models/Chart');
-    const ChartPublic = require('../models/ChartPublic');
     const ReadonlyChart = require('../models/ReadonlyChart');
     const { chart, chartUser, publicChart, publicChartUser } = t.context;
 
@@ -151,6 +151,9 @@ test('ReadonlyChart.fromPublicChart copies included model from passed chart', as
     const readonlyChartWithUser = await ReadonlyChart.fromPublicChart(chartWithUser, publicChart);
     t.is(readonlyChartWithUser.user.id, chartUser.id);
     t.is(readonlyChartWithUser.user.id, readonlyChartWithUser.dataValues.user.id);
+    // There is no Sequelize association between ChartPublic and User, therefore the `user` property
+    // (copied from Chart) can contain a different user than `author_id` (stored on `PublicChart`).
+    t.not(readonlyChartWithUser.user.id, readonlyChartWithUser.author_id);
 });
 
 test('ReadonlyChart cannot be saved', async t => {


### PR DESCRIPTION
So that for example when the chart was selected with `{ include: "user" }`, the ReadonlyChart object created from this chart contains the `User` too.