### PR TITLE
Theme.getMergedData: Don't crash on missing extend

### DIFF
--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -115,6 +115,27 @@ test('theme.getMergedData', async t => {
     t.is(data.easing, 'easeInOut');
 });
 
+test('theme.getMergedData does not get stuck in an extend loop', async t => {
+    let theme1;
+    let theme2;
+    try {
+        theme1 = await createTheme({
+            data: { foo: 1 }
+        });
+        theme2 = await createTheme({
+            data: { foo: 2, bar: 2 },
+            extend: theme1.id
+        });
+        theme1.extend = theme2.id;
+        await theme1.save();
+        const data = await theme1.getMergedData();
+        t.deepEqual(data, { foo: 1, bar: 2 });
+    } finally {
+        await destroy(theme1);
+        await destroy(theme2);
+    }
+});
+
 test('theme.getMergedAssets', async t => {
     const { theme1: theme } = t.context;
     t.is(typeof theme.getMergedAssets, 'function', 'theme.getMergedAssets() is undefined');


### PR DESCRIPTION
#### Problem

It can happen on production that there is a theme with the `extend` property that points to a parent theme that doesn't exist. This makes `Theme.getMergedData()` crash.

#### Changes

Just stop walking up the theme tree when we encounter a theme that doesn't exist and return the data we've managed to gather sofar.

Also make sure we don't get stuck in an endless extend loop and add a unit test for that.

It's unfortunately impossible to add a unit test for the "missing extend theme" case, because the database schema of the testing database doesn't allow creating such a theme (foreign key must exist).

Related PR: https://github.com/datawrapper/plugin-admin-themes/pull/4