### PR TITLE
optimize user.getActiveTeam to use pre-loaded teams if available

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -253,7 +253,7 @@ User.prototype.getActiveProduct = async function() {
 User.prototype.getActiveTeam = async function(session) {
     const { getUserData } = require('../utils/userData');
 
-    const teams = await this.getTeams();
+    const teams = this.teams || (await this.getTeams());
     if (teams.length < 1) return null;
 
     let activeTeam = await getUserData(this.id, 'active_team');


### PR DESCRIPTION
just a small optimization to make `user.getActiveTeam` use pre-cached teams (which might already have been included in the query)